### PR TITLE
[sienna.o] 로또 2단계

### DIFF
--- a/src/main/java/controller/LottoApplication.java
+++ b/src/main/java/controller/LottoApplication.java
@@ -31,9 +31,10 @@ public class LottoApplication {
                     .map(Lotto::ofManual)
                     .collect(Collectors.toList());
 
-            LottoBuyer lottoBuyer = new LottoBuyer(money);
-            PurchasedLotto purchasedLotto = lottoBuyer.buyFrom(lottoStore, manualLottos);
-            outputView.printPurchasedLottos(purchasedLotto);
+            LottoBuyer lottoBuyer = new LottoBuyer(money, lottoStore);
+            lottoBuyer.buyManual(manualLottos);
+            lottoBuyer.buyAuto();
+            outputView.printPurchasedLottos(PurchasedLotto.of(lottoBuyer));
 
             Lotto winningLotto = Lotto.ofManual(inputView.getWinningLottoInput());
             LottoNumber bonusNumber = new LottoNumber(inputView.getBonusNumberInput());

--- a/src/main/java/controller/LottoApplication.java
+++ b/src/main/java/controller/LottoApplication.java
@@ -6,9 +6,12 @@ import domain.LottoNumber;
 import domain.LottoStore;
 import dto.LottoResult;
 import dto.WinningLotto;
-import utils.NumberParser;
 import view.InputView;
 import view.OutputView;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
 
 public class LottoApplication {
 
@@ -17,19 +20,29 @@ public class LottoApplication {
         OutputView outputView = new OutputView();
 
         try {
-            String moneyInput = inputView.getMoneyInput();
-            Integer money = NumberParser.parse(moneyInput);
+            // 구입금액 입력
+            Integer money = inputView.getMoneyInput();
 
+            // 수동 구매 수 입력
+            Integer amount = inputView.getManualAmountInput();
+
+            List<Lotto> manualLottos = inputView.getManualLottosInput(amount)
+                    .stream()
+                    .map(Lotto::ofManual)
+                    .collect(Collectors.toList());
+
+            // 수동 구매 (입력) + 자동 구매 (남은 금액) 로또 구매
             LottoBuyer lottoBuyer = new LottoBuyer(money);
-            outputView.printPurchasedLottos(lottoBuyer.buyFrom(new LottoStore()));
+            outputView.printPurchasedLottos(lottoBuyer.buyFrom(new LottoStore(), manualLottos));
 
-            String winningLottoInput = inputView.getWinningLottoInput();
-            Lotto winningLotto = Lotto.ofManual(NumberParser.splitAndParse(winningLottoInput));
+            // 당첨번호 입력
+            Lotto winningLotto = Lotto.ofManual(inputView.getWinningLottoInput());
 
-            String bonusNumberInput = inputView.getBonusNumberInput();
-            LottoNumber bonusNumber = new LottoNumber(NumberParser.parse(bonusNumberInput));
+            // 보너스 번호 입력
+            LottoNumber bonusNumber = new LottoNumber(inputView.getBonusNumberInput());
             inputView.close();
 
+            // 로또 당첨 결과 출력
             LottoResult lottoResult = lottoBuyer.calculateResult(new WinningLotto(winningLotto, bonusNumber));
             outputView.printLottoStatistics(lottoResult);
         }

--- a/src/main/java/controller/LottoApplication.java
+++ b/src/main/java/controller/LottoApplication.java
@@ -5,6 +5,7 @@ import domain.LottoBuyer;
 import domain.LottoNumber;
 import domain.LottoStore;
 import dto.LottoResult;
+import dto.PurchasedLotto;
 import dto.WinningLotto;
 import view.InputView;
 import view.OutputView;
@@ -18,6 +19,7 @@ public class LottoApplication {
     public static void main(String[] args) {
         InputView inputView = new InputView();
         OutputView outputView = new OutputView();
+        LottoStore lottoStore = new LottoStore();
 
         try {
             // 구입금액 입력
@@ -33,7 +35,8 @@ public class LottoApplication {
 
             // 수동 구매 (입력) + 자동 구매 (남은 금액) 로또 구매
             LottoBuyer lottoBuyer = new LottoBuyer(money);
-            outputView.printPurchasedLottos(lottoBuyer.buyFrom(new LottoStore(), manualLottos));
+            PurchasedLotto purchasedLotto = lottoBuyer.buyFrom(lottoStore, manualLottos);
+            outputView.printPurchasedLottos(purchasedLotto);
 
             // 당첨번호 입력
             Lotto winningLotto = Lotto.ofManual(inputView.getWinningLottoInput());

--- a/src/main/java/controller/LottoApplication.java
+++ b/src/main/java/controller/LottoApplication.java
@@ -22,10 +22,8 @@ public class LottoApplication {
         LottoStore lottoStore = new LottoStore();
 
         try {
-            // 구입금액 입력
             Integer money = inputView.getMoneyInput();
 
-            // 수동 구매 수 입력
             Integer amount = inputView.getManualAmountInput();
 
             List<Lotto> manualLottos = inputView.getManualLottosInput(amount)
@@ -33,19 +31,14 @@ public class LottoApplication {
                     .map(Lotto::ofManual)
                     .collect(Collectors.toList());
 
-            // 수동 구매 (입력) + 자동 구매 (남은 금액) 로또 구매
             LottoBuyer lottoBuyer = new LottoBuyer(money);
             PurchasedLotto purchasedLotto = lottoBuyer.buyFrom(lottoStore, manualLottos);
             outputView.printPurchasedLottos(purchasedLotto);
 
-            // 당첨번호 입력
             Lotto winningLotto = Lotto.ofManual(inputView.getWinningLottoInput());
-
-            // 보너스 번호 입력
             LottoNumber bonusNumber = new LottoNumber(inputView.getBonusNumberInput());
             inputView.close();
 
-            // 로또 당첨 결과 출력
             LottoResult lottoResult = lottoBuyer.calculateResult(new WinningLotto(winningLotto, bonusNumber));
             outputView.printLottoStatistics(lottoResult);
         }

--- a/src/main/java/domain/Lotto.java
+++ b/src/main/java/domain/Lotto.java
@@ -27,7 +27,7 @@ public class Lotto {
         return new Lotto(lottoNumbers);
     }
 
-    public static Lotto ofAuto() {
+    static public Lotto ofAuto() {
         List<LottoNumber> lottoNumbers = Lotto.generate();
         return new Lotto(lottoNumbers);
     }

--- a/src/main/java/domain/Lotto.java
+++ b/src/main/java/domain/Lotto.java
@@ -1,7 +1,5 @@
 package domain;
 
-import dto.WinningLotto;
-
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -14,11 +12,11 @@ public class Lotto {
     private final List<LottoNumber> numbers;
 
     private Lotto(List<LottoNumber> numbers) {
-        validateLotto(numbers);
+        validate(numbers);
         this.numbers = numbers;
     }
 
-    static public Lotto ofManual(List<Integer> numbers) {
+    public static Lotto ofManual(List<Integer> numbers) {
         List<LottoNumber> lottoNumbers = numbers
                 .stream()
                 .map(LottoNumber::new)
@@ -27,19 +25,19 @@ public class Lotto {
         return new Lotto(lottoNumbers);
     }
 
-    static public Lotto ofAuto() {
+    public static Lotto ofAuto() {
         List<LottoNumber> lottoNumbers = Lotto.generate();
         return new Lotto(lottoNumbers);
     }
 
-    static private List<LottoNumber> generate() {
+    private static List<LottoNumber> generate() {
         Collections.shuffle(LOTTO_NUMBER_CANDIDATES);
         List<LottoNumber> lottoNumbers = new ArrayList<>(LOTTO_NUMBER_CANDIDATES.subList(0, LOTTO_SIZE));
         Collections.sort(lottoNumbers);
         return lottoNumbers;
     }
 
-    static private void validateLotto(List<LottoNumber> numbers) {
+    private static void validate(List<LottoNumber> numbers) {
         if (numbers.size() != LOTTO_SIZE) {
             throw new IllegalArgumentException(ERROR_LOTTO_SIZE);
         }
@@ -50,20 +48,18 @@ public class Lotto {
         }
     }
 
-    public LottoRank getRank(WinningLotto winningLotto) {
-        Integer matchCount = 0;
-        for(LottoNumber number : numbers) {
-            if (winningLotto.getLotto().has(number)) {
-                matchCount++;
-            }
-        }
-        return LottoRank.getRank(matchCount, numbers.contains(winningLotto.getBonusNumber()));
-    }
-
     public Boolean has(LottoNumber lottoNumber) {
         return numbers.contains(lottoNumber);
     }
 
+    public Integer matches(Lotto lotto) {
+        List<Boolean> match = numbers
+                .stream()
+                .map(lotto::has)
+                .filter(cond -> cond)
+                .collect(Collectors.toList());
+        return match.size();
+    }
     @Override
     public String toString() {
         return numbers.toString();

--- a/src/main/java/domain/LottoBuyer.java
+++ b/src/main/java/domain/LottoBuyer.java
@@ -1,6 +1,7 @@
 package domain;
 
 import dto.LottoResult;
+import dto.PurchasedLotto;
 import dto.WinningLotto;
 
 import java.util.*;
@@ -17,10 +18,11 @@ public class LottoBuyer {
         this.money = money;
     }
     
-    public List<Lotto> buyFrom(LottoPurchasePlace lottoPurchasePlace, List<Lotto> manualLottos) {
-        List<Lotto> purchasedLottos = lottoPurchasePlace.purchase(money, manualLottos);
-        this.lottos.addAll(purchasedLottos);
-        return this.lottos;
+    public PurchasedLotto buyFrom(LottoPurchasePlace lottoPurchasePlace, List<Lotto> manualLottos) {
+       PurchasedLotto purchased = lottoPurchasePlace.purchase(money, manualLottos);
+        this.lottos.addAll(purchased.getManual());
+        this.lottos.addAll(purchased.getAuto());
+        return purchased;
     }
 
     public LottoResult calculateResult(WinningLotto winningLotto) {

--- a/src/main/java/domain/LottoBuyer.java
+++ b/src/main/java/domain/LottoBuyer.java
@@ -27,7 +27,7 @@ public class LottoBuyer {
 
     public LottoResult calculateResult(WinningLotto winningLotto) {
         List<LottoRank> statuses = lottos.stream()
-                .map(lotto -> lotto.getRank(winningLotto))
+                .map(winningLotto::getRank)
                 .collect(Collectors.toList());
 
         Map<LottoRank, Integer> map = new EnumMap<>(LottoRank.class);

--- a/src/main/java/domain/LottoBuyer.java
+++ b/src/main/java/domain/LottoBuyer.java
@@ -42,7 +42,7 @@ public class LottoBuyer {
         List<Lotto> lottos = Stream.concat(manualLottos.stream(), autoLottos.stream())
                 .collect(Collectors.toList());
         List<LottoRank> statuses = lottos.stream()
-                .map(winningLotto::getRank)
+                .map(winningLotto::getLottoRank)
                 .collect(Collectors.toList());
 
         Map<LottoRank, Integer> map = new EnumMap<>(LottoRank.class);

--- a/src/main/java/domain/LottoBuyer.java
+++ b/src/main/java/domain/LottoBuyer.java
@@ -45,15 +45,11 @@ public class LottoBuyer {
             .mapToLong(entry -> entry.getValue() * entry.getKey().getReward())
             .reduce(0, Long::sum);
 
-        if (money == 0) {
-            return 0.00d;
-        }
         Integer investMoney = (money / LOTTO_COST) * LOTTO_COST;
-
-        if ((earningMoney - investMoney) == 0) {
+        Double rate = ((earningMoney - investMoney) / (double) investMoney) * 100;
+        if (investMoney == 0) {
             return 0.00d;
         }
-        Double rate = (earningMoney - investMoney) / (double) investMoney * 100;
         return Math.floor(rate * RATE_DECIMAL_POINT) / RATE_DECIMAL_POINT;
     }
 }

--- a/src/main/java/domain/LottoBuyer.java
+++ b/src/main/java/domain/LottoBuyer.java
@@ -17,8 +17,8 @@ public class LottoBuyer {
         this.money = money;
     }
     
-    public List<Lotto> buyFrom(LottoPurchasePlace lottoPurchasePlace) {
-        List<Lotto> purchasedLottos = lottoPurchasePlace.purchase(money);
+    public List<Lotto> buyFrom(LottoPurchasePlace lottoPurchasePlace, List<Lotto> manualLottos) {
+        List<Lotto> purchasedLottos = lottoPurchasePlace.purchase(money, manualLottos);
         this.lottos.addAll(purchasedLottos);
         return this.lottos;
     }

--- a/src/main/java/domain/LottoBuyer.java
+++ b/src/main/java/domain/LottoBuyer.java
@@ -1,31 +1,46 @@
 package domain;
 
 import dto.LottoResult;
-import dto.PurchasedLotto;
 import dto.WinningLotto;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 public class LottoBuyer {
-    private static final Integer LOTTO_COST = 1000;
+    private static final Integer LOTTO_COST = LottoStore.LOTTO_COST;
     private static final Integer RATE_DECIMAL_POINT = 100;
 
+    private final LottoStore lottoStore;
     private Integer money;
-    private List<Lotto> lottos = new ArrayList<>();
+    private List<Lotto> manualLottos = new ArrayList<>();
+    private List<Lotto> autoLottos = new ArrayList<>();
 
-    public LottoBuyer(Integer money) {
+    public LottoBuyer(Integer money, LottoStore lottoStore) {
         this.money = money;
+        this.lottoStore = lottoStore;
     }
-    
-    public PurchasedLotto buyFrom(LottoPurchasePlace lottoPurchasePlace, List<Lotto> manualLottos) {
-       PurchasedLotto purchased = lottoPurchasePlace.purchase(money, manualLottos);
-        this.lottos.addAll(purchased.getManual());
-        this.lottos.addAll(purchased.getAuto());
-        return purchased;
+
+    public void buyManual(List<Lotto> manaulLottos) {
+        lottoStore.validatePurchase(money, manaulLottos.size());
+
+        this.manualLottos = new ArrayList<>(manaulLottos);
+        money -= manaulLottos.size() * LOTTO_COST;
+    }
+
+    public void buyAuto() {
+        Integer amount = lottoStore.getPurchaseAmount(money);
+
+        this.autoLottos = IntStream.range(0, amount)
+                .mapToObj((i) -> Lotto.ofAuto())
+                .collect(Collectors.toList());
+        money -= autoLottos.size() * LOTTO_COST;
     }
 
     public LottoResult calculateResult(WinningLotto winningLotto) {
+        List<Lotto> lottos = Stream.concat(manualLottos.stream(), autoLottos.stream())
+                .collect(Collectors.toList());
         List<LottoRank> statuses = lottos.stream()
                 .map(winningLotto::getRank)
                 .collect(Collectors.toList());
@@ -39,17 +54,25 @@ public class LottoBuyer {
         return new LottoResult(map, earningRate);
     }
 
-    public Double calculateEarningRate(Map<LottoRank, Integer> map) {
+    private Double calculateEarningRate(Map<LottoRank, Integer> map) {
         Long earningMoney = map.entrySet()
             .stream()
             .mapToLong(entry -> entry.getValue() * entry.getKey().getReward())
             .reduce(0, Long::sum);
 
-        Integer investMoney = (money / LOTTO_COST) * LOTTO_COST;
+        Integer investMoney = (autoLottos.size() + manualLottos.size()) * LOTTO_COST;
         Double rate = ((earningMoney - investMoney) / (double) investMoney) * 100;
         if (investMoney == 0) {
             return 0.00d;
         }
         return Math.floor(rate * RATE_DECIMAL_POINT) / RATE_DECIMAL_POINT;
+    }
+
+    public List<Lotto> getManualLottos() {
+        return manualLottos;
+    }
+
+    public List<Lotto> getAutoLottos() {
+        return autoLottos;
     }
 }

--- a/src/main/java/domain/LottoPurchasePlace.java
+++ b/src/main/java/domain/LottoPurchasePlace.java
@@ -3,5 +3,5 @@ package domain;
 import java.util.List;
 
 public interface LottoPurchasePlace {
-    List<Lotto> purchase(Integer amount);
+    List<Lotto> purchase(Integer money, List<Lotto> manualLottos);
 }

--- a/src/main/java/domain/LottoPurchasePlace.java
+++ b/src/main/java/domain/LottoPurchasePlace.java
@@ -1,9 +1,0 @@
-package domain;
-
-import dto.PurchasedLotto;
-
-import java.util.List;
-
-public interface LottoPurchasePlace {
-    PurchasedLotto purchase(Integer money, List<Lotto> manualLottos);
-}

--- a/src/main/java/domain/LottoPurchasePlace.java
+++ b/src/main/java/domain/LottoPurchasePlace.java
@@ -1,7 +1,9 @@
 package domain;
 
+import dto.PurchasedLotto;
+
 import java.util.List;
 
 public interface LottoPurchasePlace {
-    List<Lotto> purchase(Integer money, List<Lotto> manualLottos);
+    PurchasedLotto purchase(Integer money, List<Lotto> manualLottos);
 }

--- a/src/main/java/domain/LottoStore.java
+++ b/src/main/java/domain/LottoStore.java
@@ -1,25 +1,40 @@
 package domain;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class LottoStore implements LottoPurchasePlace {
     private static final Integer LOTTO_COST = 1000;
-    private static final String ERROR_MONEY_LOWER_THEN_COST = "로또를 구매하기 위한 최소 금액이 부족합니다.";
+    private static final String ERROR_MONEY_LOWER_THEN_COST = "로또를 구매하기 위한 금액이 부족합니다.";
+    private static final String ERROR_PURCHASE_NOTHING = "로또를 ";
 
     @Override
-    public List<Lotto> purchase(Integer money) {
+    public List<Lotto> purchase(Integer money, List<Lotto> manualLottos) {
+        Integer remainMoney = money - manualLottos.size() * LOTTO_COST;
+        if (remainMoney < 0) {
+            throw new IllegalArgumentException(ERROR_MONEY_LOWER_THEN_COST);
+        }
+
+        List<Lotto> result = new ArrayList<>(manualLottos);
+        if (remainMoney >= LOTTO_COST) {
+            result.addAll(purchaseAuto(remainMoney));
+        }
+
+        if (result.size()==0) {
+            throw new IllegalArgumentException(ERROR_PURCHASE_NOTHING);
+        }
+        return result;
+    }
+
+    private List<Lotto> purchaseAuto(Integer money) {
         return IntStream
                 .range(0, getAmount(money))
                 .mapToObj((number) -> Lotto.ofAuto())
                 .collect(Collectors.toList());
     }
-
     private Integer getAmount(Integer money) {
-        if (money < LOTTO_COST) {
-            throw new IllegalArgumentException(ERROR_MONEY_LOWER_THEN_COST);
-        }
         return money / LOTTO_COST;
     }
 }

--- a/src/main/java/domain/LottoStore.java
+++ b/src/main/java/domain/LottoStore.java
@@ -1,37 +1,11 @@
 package domain;
 
-import dto.PurchasedLotto;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-public class LottoStore implements LottoPurchasePlace {
-    private static final Integer LOTTO_COST = 1000;
+public class LottoStore {
+    public static final Integer LOTTO_COST = 1000;
     private static final String ERROR_MONEY_LOWER_THAN_COST = "로또를 구매하기 위한 금액이 부족합니다.";
     private static final String ERROR_PURCHASE_NOTHING = "구매 금액이 로또 가격보다 작아 구매할 수 없습니다.";
 
-    @Override
-    public PurchasedLotto purchase(Integer money, List<Lotto> manualLottos) {
-        validateMoney(money, manualLottos.size());
-
-        List<Lotto> autoLottos = new ArrayList<>();
-        Integer remainMoney = money - manualLottos.size() * LOTTO_COST;
-        if (remainMoney >= LOTTO_COST) {
-            autoLottos = purchaseAuto(remainMoney);
-        }
-        return new PurchasedLotto(manualLottos, autoLottos);
-    }
-
-    private List<Lotto> purchaseAuto(Integer money) {
-        return IntStream
-                .range(0, getAmount(money))
-                .mapToObj((number) -> Lotto.ofAuto())
-                .collect(Collectors.toList());
-    }
-
-    private void validateMoney(Integer money, Integer amount) {
+    public void validatePurchase(Integer money, Integer amount) {
         if (money < LOTTO_COST) {
             throw new IllegalArgumentException(ERROR_PURCHASE_NOTHING);
         }
@@ -40,7 +14,7 @@ public class LottoStore implements LottoPurchasePlace {
         }
     }
 
-    private Integer getAmount(Integer money) {
+    public Integer getPurchaseAmount(Integer money) {
         return money / LOTTO_COST;
     }
 }

--- a/src/main/java/domain/LottoStore.java
+++ b/src/main/java/domain/LottoStore.java
@@ -1,5 +1,7 @@
 package domain;
 
+import dto.PurchasedLotto;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -7,25 +9,19 @@ import java.util.stream.IntStream;
 
 public class LottoStore implements LottoPurchasePlace {
     private static final Integer LOTTO_COST = 1000;
-    private static final String ERROR_MONEY_LOWER_THEN_COST = "로또를 구매하기 위한 금액이 부족합니다.";
-    private static final String ERROR_PURCHASE_NOTHING = "로또를 ";
+    private static final String ERROR_MONEY_LOWER_THAN_COST = "로또를 구매하기 위한 금액이 부족합니다.";
+    private static final String ERROR_PURCHASE_NOTHING = "구매 금액이 로또 가격보다 작아 구매할 수 없습니다.";
 
     @Override
-    public List<Lotto> purchase(Integer money, List<Lotto> manualLottos) {
+    public PurchasedLotto purchase(Integer money, List<Lotto> manualLottos) {
+        validateMoney(money, manualLottos.size());
+
+        List<Lotto> autoLottos = new ArrayList<>();
         Integer remainMoney = money - manualLottos.size() * LOTTO_COST;
-        if (remainMoney < 0) {
-            throw new IllegalArgumentException(ERROR_MONEY_LOWER_THEN_COST);
-        }
-
-        List<Lotto> result = new ArrayList<>(manualLottos);
         if (remainMoney >= LOTTO_COST) {
-            result.addAll(purchaseAuto(remainMoney));
+            autoLottos = purchaseAuto(remainMoney);
         }
-
-        if (result.size()==0) {
-            throw new IllegalArgumentException(ERROR_PURCHASE_NOTHING);
-        }
-        return result;
+        return new PurchasedLotto(manualLottos, autoLottos);
     }
 
     private List<Lotto> purchaseAuto(Integer money) {
@@ -34,6 +30,16 @@ public class LottoStore implements LottoPurchasePlace {
                 .mapToObj((number) -> Lotto.ofAuto())
                 .collect(Collectors.toList());
     }
+
+    private void validateMoney(Integer money, Integer amount) {
+        if (money < LOTTO_COST) {
+            throw new IllegalArgumentException(ERROR_PURCHASE_NOTHING);
+        }
+        if ((money - (amount * LOTTO_COST)) < 0) {
+            throw new IllegalArgumentException(ERROR_MONEY_LOWER_THAN_COST);
+        }
+    }
+
     private Integer getAmount(Integer money) {
         return money / LOTTO_COST;
     }

--- a/src/main/java/dto/PurchasedLotto.java
+++ b/src/main/java/dto/PurchasedLotto.java
@@ -1,0 +1,23 @@
+package dto;
+
+import domain.Lotto;
+
+import java.util.List;
+
+public class PurchasedLotto {
+    private final List<Lotto> manual;
+    private final List<Lotto> auto;
+
+    public PurchasedLotto(List<Lotto> manual, List<Lotto> auto) {
+        this.manual = manual;
+        this.auto = auto;
+    }
+
+    public List<Lotto> getManual() {
+        return manual;
+    }
+
+    public List<Lotto> getAuto() {
+        return auto;
+    }
+}

--- a/src/main/java/dto/PurchasedLotto.java
+++ b/src/main/java/dto/PurchasedLotto.java
@@ -1,6 +1,7 @@
 package dto;
 
 import domain.Lotto;
+import domain.LottoBuyer;
 
 import java.util.List;
 
@@ -8,9 +9,13 @@ public class PurchasedLotto {
     private final List<Lotto> manual;
     private final List<Lotto> auto;
 
-    public PurchasedLotto(List<Lotto> manual, List<Lotto> auto) {
+    private PurchasedLotto(List<Lotto> manual, List<Lotto> auto) {
         this.manual = manual;
         this.auto = auto;
+    }
+
+    public static PurchasedLotto of(LottoBuyer lottoBuyer) {
+        return new PurchasedLotto(lottoBuyer.getManualLottos(), lottoBuyer.getAutoLottos());
     }
 
     public List<Lotto> getManual() {

--- a/src/main/java/dto/WinningLotto.java
+++ b/src/main/java/dto/WinningLotto.java
@@ -22,7 +22,7 @@ public class WinningLotto {
         }
     }
 
-    public LottoRank getRank(Lotto lotto) {
+    public LottoRank getLottoRank(Lotto lotto) {
         return LottoRank.getRank(lotto.matches(this.lotto), lotto.has(bonusNumber));
     }
 }

--- a/src/main/java/dto/WinningLotto.java
+++ b/src/main/java/dto/WinningLotto.java
@@ -6,6 +6,7 @@ import domain.LottoRank;
 
 public class WinningLotto {
     private static final String ERROR_BONUS_DUPLICATE = "보너스번호와 당첨번호는 중복될 수 없습니다.";
+
     private final Lotto lotto;
     private final LottoNumber bonusNumber;
 
@@ -23,12 +24,5 @@ public class WinningLotto {
 
     public LottoRank getRank(Lotto lotto) {
         return LottoRank.getRank(lotto.matches(this.lotto), lotto.has(bonusNumber));
-    }
-    public Lotto getLotto() {
-        return lotto;
-    }
-
-    public LottoNumber getBonusNumber() {
-        return bonusNumber;
     }
 }

--- a/src/main/java/dto/WinningLotto.java
+++ b/src/main/java/dto/WinningLotto.java
@@ -2,6 +2,7 @@ package dto;
 
 import domain.Lotto;
 import domain.LottoNumber;
+import domain.LottoRank;
 
 public class WinningLotto {
     private static final String ERROR_BONUS_DUPLICATE = "보너스번호와 당첨번호는 중복될 수 없습니다.";
@@ -20,6 +21,9 @@ public class WinningLotto {
         }
     }
 
+    public LottoRank getRank(Lotto lotto) {
+        return LottoRank.getRank(lotto.matches(this.lotto), lotto.has(bonusNumber));
+    }
     public Lotto getLotto() {
         return lotto;
     }

--- a/src/main/java/view/InputView.java
+++ b/src/main/java/view/InputView.java
@@ -1,10 +1,18 @@
 package view;
 
+import domain.Lotto;
+import utils.NumberParser;
+
+import java.util.List;
 import java.util.Scanner;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class InputView {
     private static final String NOTICE_MONEY_INPUT = "구매금액을 입력해 주세요.";
-    private static final String NOTICE_WINNING_NUMBERS_INPUT = "지난 주 당첨 번호를 입력해 주세요.";
+    private static final String NOTICE_MANUAL_AMOUNT_INPUT = "수동으로 구매할 로또 수를 입력해 주세요.";
+    private static final String NOTICE_MANUAL_LOTTO_INPUT = "수동으로 구매할 번호를 입력해 주세요.";
+    private static final String NOTICE_WINNING_LOTTO_INPUT = "지난 주 당첨 번호를 입력해 주세요.";
     private static final String NOTICE_BONUS_NUMBER_INPUT = "보너스 볼을 입력해 주세요.";
 
     private final Scanner scanner;
@@ -17,22 +25,43 @@ public class InputView {
         scanner.close();
     }
 
-    public String getMoneyInput() {
+    public Integer getMoneyInput() {
         System.out.println(NOTICE_MONEY_INPUT);
         String input =  scanner.next();
         scanner.nextLine();
-        return input;
+        return NumberParser.parse(input);
     }
 
-    public String getWinningLottoInput() {
-        System.out.println(NOTICE_WINNING_NUMBERS_INPUT);
-        return scanner.nextLine();
+    public Integer getManualAmountInput() {
+        System.out.println(NOTICE_MANUAL_AMOUNT_INPUT);
+        String input =  scanner.next();
+        scanner.nextLine();
+        return NumberParser.parse(input);
     }
 
-    public String getBonusNumberInput() {
+    public List<List<Integer>> getManualLottosInput(Integer amount) {
+        System.out.println(NOTICE_MANUAL_LOTTO_INPUT);
+        return IntStream.range(0, amount)
+                .mapToObj((i)-> getManualLottoInput())
+                .collect(Collectors.toList());
+
+    }
+    private List<Integer> getManualLottoInput() {
+        String input = scanner.nextLine();
+        return NumberParser.splitAndParse(input);
+    }
+
+    public List<Integer> getWinningLottoInput() {
+        System.out.println(NOTICE_WINNING_LOTTO_INPUT);
+        String input = scanner.nextLine();
+        return NumberParser.splitAndParse(input);
+    }
+
+    public Integer getBonusNumberInput() {
         System.out.println(NOTICE_BONUS_NUMBER_INPUT);
         String input =  scanner.next();
         scanner.nextLine();
-        return input;
+        return NumberParser.parse(input);
     }
+
 }

--- a/src/main/java/view/OutputView.java
+++ b/src/main/java/view/OutputView.java
@@ -3,21 +3,24 @@ package view;
 import domain.Lotto;
 import domain.LottoRank;
 import dto.LottoResult;
+import dto.PurchasedLotto;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 public class OutputView {
 
-    public void printPurchasedLottos(List<Lotto> lottos) {
-        System.out.println(lottos.size() + "개를 구매했습니다.");
-        for(Lotto lotto : lottos) {
-            System.out.println(lotto.toString());
-        }
+    public void printPurchasedLottos(PurchasedLotto purchased) {
+        System.out.print("수동으로 " + purchased.getManual().size() + "개, ");
+        System.out.print("자동으로 " + purchased.getAuto().size() + "개");
+        System.out.println("를 구매했습니다.");
+        Stream.concat(purchased.getManual().stream(), purchased.getAuto().stream())
+                .forEach((System.out::println));
     }
 
     public void printLottoStatistics(LottoResult lottoResult) {
         for (LottoRank place : LottoRank.values()) {
-            System.out.print(place.toString());
+            System.out.print(place);
             System.out.print(" - ");
             System.out.print(lottoResult.getLottoRanks().get(place));
             System.out.println("개");

--- a/src/test/java/domain/LottoBuyerTest.java
+++ b/src/test/java/domain/LottoBuyerTest.java
@@ -1,79 +1,92 @@
 package domain;
 
 import dto.LottoResult;
-import dto.PurchasedLotto;
 import dto.WinningLotto;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LottoBuyerTest {
-    @Test
-    void 로또를_구매한다() {
+
+    @ValueSource(ints = {10000, 2000, 4000})
+    @ParameterizedTest
+    void 로또를_구매금액만큼_자동으로_구매한다(int money) {
         // given
-        List<Lotto> lottos = List.of(Lotto.ofAuto(), Lotto.ofAuto());
-        LottoBuyer buyer = new LottoBuyer(5000);
-        LottoPurchasePlace place = ((money, manuals) ->
-                new PurchasedLotto(lottos, Collections.emptyList()));
+        LottoBuyer lottoBuyer = new LottoBuyer(money, new LottoStore());
 
         // when
-        PurchasedLotto purchasedLotto = buyer.buyFrom(place, Collections.emptyList());
+        lottoBuyer.buyAuto();
 
         // then
-        assertThat(purchasedLotto.getManual()).isEqualTo(lottos);
+        assertThat(lottoBuyer.getAutoLottos().size()).isEqualTo(money / LottoStore.LOTTO_COST);
+    }
+
+    @Test
+    void 로또를_수동으로_구매한다() {
+        // given
+        int money = 2300;
+        LottoBuyer lottoBuyer = new LottoBuyer(money, new LottoStore());
+        List<Lotto> manualLottos = List.of(
+                Lotto.ofManual(List.of(1, 2, 3, 4, 5, 6)),
+                Lotto.ofManual(List.of(7, 8, 9, 10, 11, 12))
+                );
+
+        // when
+        lottoBuyer.buyManual(manualLottos);
+
+        // then
+        assertThat(lottoBuyer.getManualLottos()).containsExactlyElementsOf(manualLottos);
     }
 
     @Test
     void 로또_당첨_등수를_확인한다() {
         // given
-        List<Lotto> lottos = List.of(
+        List<Lotto> manual = List.of(
                 Lotto.ofManual(List.of(1,2,3,4,5,6)),
                 Lotto.ofManual(List.of(3,4,5,6,7,8)),
                 Lotto.ofManual(List.of(5,6,7,8,9,10))
         );
-        LottoBuyer lottoBuyer = new LottoBuyer(3500);
-        LottoPurchasePlace place = ((money, manuals) ->
-                new PurchasedLotto(lottos, Collections.emptyList()));
-        lottoBuyer.buyFrom(place, Collections.emptyList());
+        LottoBuyer lottoBuyer = new LottoBuyer(3500,  new LottoStore());
+        lottoBuyer.buyManual(manual);
 
-        Lotto winningNumbers = Lotto.ofManual(List.of(1, 2, 3, 4, 5, 6));
-        LottoNumber bonusNumber = new LottoNumber(45);
-        WinningLotto winningLotto = new WinningLotto(winningNumbers, bonusNumber);
+        WinningLotto winningLotto = new WinningLotto(Lotto.ofManual(List.of(1, 2, 3, 4, 5, 6)), new LottoNumber(45));
 
         // when
         LottoResult lottoResult = lottoBuyer.calculateResult(winningLotto);
+        Map<LottoRank, Integer> lottoRanks = lottoResult.getLottoRanks();
 
         // then
-        assertThat(lottoResult.getLottoRanks().get(LottoRank.FIRST_RANK)).isEqualTo(1);
-        assertThat(lottoResult.getLottoRanks().get(LottoRank.SECOND_RANK)).isEqualTo(0);
-        assertThat(lottoResult.getLottoRanks().get(LottoRank.THIRD_RANK)).isEqualTo(0);
-        assertThat(lottoResult.getLottoRanks().get(LottoRank.FOURTH_RANK)).isEqualTo(1);
-        assertThat(lottoResult.getLottoRanks().get(LottoRank.FIFTH_RANK)).isEqualTo(0);
+        assertThat(lottoRanks.get(LottoRank.FIRST_RANK)).isEqualTo(1);
+        assertThat(lottoRanks.get(LottoRank.SECOND_RANK)).isEqualTo(0);
+        assertThat(lottoRanks.get(LottoRank.THIRD_RANK)).isEqualTo(0);
+        assertThat(lottoRanks.get(LottoRank.FOURTH_RANK)).isEqualTo(1);
+        assertThat(lottoRanks.get(LottoRank.FIFTH_RANK)).isEqualTo(0);
     }
 
     @Test
     void 로또_수익률을_계산한다() {
         // given
-        List<Lotto> lottos = List.of(
+        List<Lotto> manual = List.of(
                 Lotto.ofManual(List.of(1,2,3,4,5,6)),
                 Lotto.ofManual(List.of(3,4,5,6,7,8)),
                 Lotto.ofManual(List.of(5,6,7,8,9,10))
         );
-        LottoBuyer lottoBuyer = new LottoBuyer(3500);
-        LottoPurchasePlace place = ((money, manuals) ->
-                new PurchasedLotto(lottos, Collections.emptyList()));
-        lottoBuyer.buyFrom(place, Collections.emptyList());
+        LottoBuyer lottoBuyer = new LottoBuyer(3500, new LottoStore());
+        lottoBuyer.buyManual(manual);
 
-        Lotto winningNumbers = Lotto.ofManual(List.of(1, 2, 3, 4, 5, 6));
-        LottoNumber bonusNumber = new LottoNumber(45);
-        WinningLotto winningLotto = new WinningLotto(winningNumbers, bonusNumber);
+        WinningLotto winningLotto = new WinningLotto(Lotto.ofManual(List.of(1, 2, 3, 4, 5, 6)), new LottoNumber(45));
 
+
+        // when
         LottoResult lottoResult = lottoBuyer.calculateResult(winningLotto);
+        Double rate = lottoResult.getEarningRate();
 
-        // when, then
-        assertThat(lottoBuyer.calculateEarningRate(lottoResult.getLottoRanks())).isEqualTo(66668233.33);
+        // then
+        assertThat(rate).isEqualTo(66668233.33);
     }
 }

--- a/src/test/java/domain/LottoBuyerTest.java
+++ b/src/test/java/domain/LottoBuyerTest.java
@@ -1,6 +1,7 @@
 package domain;
 
 import dto.LottoResult;
+import dto.PurchasedLotto;
 import dto.WinningLotto;
 import org.junit.jupiter.api.Test;
 
@@ -15,13 +16,14 @@ public class LottoBuyerTest {
         // given
         List<Lotto> lottos = List.of(Lotto.ofAuto(), Lotto.ofAuto());
         LottoBuyer buyer = new LottoBuyer(5000);
-        LottoPurchasePlace place = ((money, manuals) -> lottos);
+        LottoPurchasePlace place = ((money, manuals) ->
+                new PurchasedLotto(lottos, Collections.emptyList()));
 
         // when
-        List<Lotto> result = buyer.buyFrom(place, Collections.emptyList());
+        PurchasedLotto purchasedLotto = buyer.buyFrom(place, Collections.emptyList());
 
         // then
-        assertThat(result).isEqualTo(lottos);
+        assertThat(purchasedLotto.getManual()).isEqualTo(lottos);
     }
 
     @Test
@@ -33,7 +35,8 @@ public class LottoBuyerTest {
                 Lotto.ofManual(List.of(5,6,7,8,9,10))
         );
         LottoBuyer lottoBuyer = new LottoBuyer(3500);
-        LottoPurchasePlace place = ((money, manuals) -> lottos);
+        LottoPurchasePlace place = ((money, manuals) ->
+                new PurchasedLotto(lottos, Collections.emptyList()));
         lottoBuyer.buyFrom(place, Collections.emptyList());
 
         Lotto winningNumbers = Lotto.ofManual(List.of(1, 2, 3, 4, 5, 6));
@@ -60,7 +63,8 @@ public class LottoBuyerTest {
                 Lotto.ofManual(List.of(5,6,7,8,9,10))
         );
         LottoBuyer lottoBuyer = new LottoBuyer(3500);
-        LottoPurchasePlace place = ((money, manuals) -> lottos);
+        LottoPurchasePlace place = ((money, manuals) ->
+                new PurchasedLotto(lottos, Collections.emptyList()));
         lottoBuyer.buyFrom(place, Collections.emptyList());
 
         Lotto winningNumbers = Lotto.ofManual(List.of(1, 2, 3, 4, 5, 6));

--- a/src/test/java/domain/LottoBuyerTest.java
+++ b/src/test/java/domain/LottoBuyerTest.java
@@ -4,6 +4,7 @@ import dto.LottoResult;
 import dto.WinningLotto;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,9 +15,10 @@ public class LottoBuyerTest {
         // given
         List<Lotto> lottos = List.of(Lotto.ofAuto(), Lotto.ofAuto());
         LottoBuyer buyer = new LottoBuyer(5000);
+        LottoPurchasePlace place = ((money, manuals) -> lottos);
 
         // when
-        List<Lotto> result = buyer.buyFrom((money)->lottos);
+        List<Lotto> result = buyer.buyFrom(place, Collections.emptyList());
 
         // then
         assertThat(result).isEqualTo(lottos);
@@ -31,7 +33,8 @@ public class LottoBuyerTest {
                 Lotto.ofManual(List.of(5,6,7,8,9,10))
         );
         LottoBuyer lottoBuyer = new LottoBuyer(3500);
-        lottoBuyer.buyFrom((money) -> lottos);
+        LottoPurchasePlace place = ((money, manuals) -> lottos);
+        lottoBuyer.buyFrom(place, Collections.emptyList());
 
         Lotto winningNumbers = Lotto.ofManual(List.of(1, 2, 3, 4, 5, 6));
         LottoNumber bonusNumber = new LottoNumber(45);
@@ -57,7 +60,8 @@ public class LottoBuyerTest {
                 Lotto.ofManual(List.of(5,6,7,8,9,10))
         );
         LottoBuyer lottoBuyer = new LottoBuyer(3500);
-        lottoBuyer.buyFrom((money) -> lottos);
+        LottoPurchasePlace place = ((money, manuals) -> lottos);
+        lottoBuyer.buyFrom(place, Collections.emptyList());
 
         Lotto winningNumbers = Lotto.ofManual(List.of(1, 2, 3, 4, 5, 6));
         LottoNumber bonusNumber = new LottoNumber(45);

--- a/src/test/java/domain/LottoStoreTest.java
+++ b/src/test/java/domain/LottoStoreTest.java
@@ -1,8 +1,10 @@
 package domain;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,27 +15,75 @@ public class LottoStoreTest {
 
     @ValueSource(ints = {10000, 2000, 4000})
     @ParameterizedTest
-    void 구매금액만큼_로또를_구매한다(int money) {
+    void 로또를_구매금액만큼_자동으로_구매한다(int money) {
         // given
         LottoStore lottoStore = new LottoStore();
 
         // when
-        List<Lotto> lottos = lottoStore.purchase(money);
+        List<Lotto> lottos = lottoStore.purchase(money, Collections.emptyList());
 
         // then
-        assertThat(lottos.size()).isEqualTo(money/LOTTO_COST);
+        assertThat(lottos.size()).isEqualTo(money / LOTTO_COST);
     }
 
     @ValueSource(ints = {500, 0, -1, -100, -2000})
     @ParameterizedTest
-    void 구매금액이_부족할_경우_예외가_발생한다(int money) {
+    void 로또를_하나도_구매하지_못했을_경우_예외가_발생한다(int money) {
         // given
         LottoStore lottoStore = new LottoStore();
 
         // when, then
-        assertThatThrownBy(() -> lottoStore.purchase(money))
+        assertThatThrownBy(() -> lottoStore.purchase(money, Collections.emptyList()))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    void 로또를_수동으로_구매한다() {
+        // given
+        int money = 2300;
+        List<Lotto> manualLottos = List.of(
+                Lotto.ofManual(List.of(1, 2, 3, 4, 5, 6)),
+                Lotto.ofManual(List.of(7, 8, 9, 10, 11, 12))
+                );
+        LottoStore lottoStore = new LottoStore();
 
+        // when
+        List<Lotto> lottos = lottoStore.purchase(money, manualLottos);
+
+        // then
+        assertThat(lottos).containsAll(manualLottos);
+    }
+
+    @Test
+    void 로또를_수동으로_구매_후_구매금액이_남으면_해당_금액만큼_자동으로_구매된다() {
+        // given
+        int money = 5000;
+        List<Lotto> manualLottos = List.of(
+                Lotto.ofManual(List.of(1, 2, 3, 4, 5, 6)),
+                Lotto.ofManual(List.of(7, 8, 9, 10, 11, 12))
+                );
+        LottoStore lottoStore = new LottoStore();
+
+        // when
+        List<Lotto> lottos = lottoStore.purchase(money, manualLottos);
+
+        // then
+        assertThat(lottos.size()).isEqualTo(money / LOTTO_COST);
+        assertThat(lottos).containsAll(manualLottos);
+    }
+
+    @Test
+    void 구매하고자_하는_수동_로또보다_구매금액이_부족할_경우_예외가_발생한다() {
+        // given
+        int money = 1999;
+        List<Lotto> manualLottos = List.of(
+                Lotto.ofManual(List.of(1, 2, 3, 4, 5, 6)),
+                Lotto.ofManual(List.of(7, 8, 9, 10, 11, 12))
+        );
+        LottoStore lottoStore = new LottoStore();
+
+        // when, then
+        assertThatThrownBy(() -> lottoStore.purchase(money, manualLottos))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/src/test/java/domain/LottoStoreTest.java
+++ b/src/test/java/domain/LottoStoreTest.java
@@ -1,5 +1,6 @@
 package domain;
 
+import dto.PurchasedLotto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -20,10 +21,10 @@ public class LottoStoreTest {
         LottoStore lottoStore = new LottoStore();
 
         // when
-        List<Lotto> lottos = lottoStore.purchase(money, Collections.emptyList());
+        PurchasedLotto purchase = lottoStore.purchase(money, Collections.emptyList());
 
         // then
-        assertThat(lottos.size()).isEqualTo(money / LOTTO_COST);
+        assertThat(purchase.getAuto().size()).isEqualTo(money / LOTTO_COST);
     }
 
     @ValueSource(ints = {500, 0, -1, -100, -2000})
@@ -48,10 +49,10 @@ public class LottoStoreTest {
         LottoStore lottoStore = new LottoStore();
 
         // when
-        List<Lotto> lottos = lottoStore.purchase(money, manualLottos);
+        PurchasedLotto purchase = lottoStore.purchase(money, manualLottos);
 
         // then
-        assertThat(lottos).containsAll(manualLottos);
+        assertThat(purchase.getManual()).containsExactlyElementsOf(manualLottos);
     }
 
     @Test
@@ -65,11 +66,12 @@ public class LottoStoreTest {
         LottoStore lottoStore = new LottoStore();
 
         // when
-        List<Lotto> lottos = lottoStore.purchase(money, manualLottos);
+        PurchasedLotto purchase = lottoStore.purchase(money, manualLottos);
 
         // then
-        assertThat(lottos.size()).isEqualTo(money / LOTTO_COST);
-        assertThat(lottos).containsAll(manualLottos);
+        assertThat(purchase.getAuto().size()).isEqualTo(3);
+        assertThat(purchase.getManual().size()).isEqualTo(2);
+        assertThat(purchase.getManual()).containsExactlyElementsOf(manualLottos);
     }
 
     @Test

--- a/src/test/java/domain/LottoTest.java
+++ b/src/test/java/domain/LottoTest.java
@@ -1,12 +1,13 @@
 package domain;
 
-import dto.WinningLotto;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LottoTest {
     @Test
@@ -30,32 +31,36 @@ public class LottoTest {
     }
 
     @Test
-    void 로또는_자신의_당첨등수를_알_수_있다_1등() {
+    void 로또는_가진_로또번호를_알_수_있다() {
         // given
-        List<Integer> numbers = List.of(1, 2, 3, 4, 5, 6);
-
+        List<Integer> numbers = List.of(23, 25, 45, 34, 5, 7);
         Lotto lotto = Lotto.ofManual(numbers);
-        WinningLotto winningLotto = new WinningLotto(Lotto.ofManual(numbers), new LottoNumber(7));
 
-        // when
-        LottoRank place = lotto.getRank(winningLotto);
-
-        // then
-        assertThat(place).isEqualTo(LottoRank.FIRST_RANK);
+        // when, then
+        numbers.forEach(number -> assertTrue(lotto.has(new LottoNumber(number))));
     }
 
     @Test
-    void 로또는_자신의_당첨등수를_알_수_있다_2등() {
+    void 로또는_가지지_않은_로또번호를_알_수_있다() {
         // given
-        List<Integer> numbers = List.of(1, 2, 3, 4, 5, 11);
+        List<Integer> numbers = List.of(23, 25, 45, 34, 5, 7);
+        List<Integer> notHasNumbers = List.of(1, 44, 2, 24, 4, 6);
+        Lotto lotto = Lotto.ofManual(numbers);
 
-        Lotto lotto = Lotto.ofManual(List.of(1, 2, 3, 4, 5, 7));
-        WinningLotto winningLotto = new WinningLotto(Lotto.ofManual(numbers), new LottoNumber(7));
+        // when, then
+        notHasNumbers.forEach(number -> assertFalse(lotto.has(new LottoNumber(number))));
+    }
+
+    @Test
+    void 로또는_다른_로또와_동일_번호_개수를_알_수_있다() {
+        // given
+        Lotto lotto = Lotto.ofManual(List.of(23, 25, 45, 34, 5, 7));
+        Lotto other = Lotto.ofManual(List.of(23, 25, 1, 2, 3, 4));
 
         // when
-        LottoRank place = lotto.getRank(winningLotto);
+        Integer result = lotto.matches(other);
 
         // then
-        assertThat(place).isEqualTo(LottoRank.SECOND_RANK);
+        assertThat(result).isEqualTo(2);
     }
 }

--- a/src/test/java/dto/WinningLottoTest.java
+++ b/src/test/java/dto/WinningLottoTest.java
@@ -2,10 +2,12 @@ package dto;
 
 import domain.Lotto;
 import domain.LottoNumber;
+import domain.LottoRank;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class WinningLottoTest {
@@ -18,5 +20,33 @@ public class WinningLottoTest {
         // when, then
         assertThatThrownBy(() -> new WinningLotto((lotto), bonusNumber))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 당첨로또는_로또의_당첨등수를_알_수_있다_1등() {
+        // given
+        List<Integer> numbers = List.of(1, 2, 3, 4, 5, 6);
+        Lotto lotto = Lotto.ofManual(numbers);
+        WinningLotto winningLotto = new WinningLotto(Lotto.ofManual(numbers), new LottoNumber(7));
+
+        // when
+        LottoRank place = winningLotto.getRank(lotto);
+
+        // then
+        assertThat(place).isEqualTo(LottoRank.FIRST_RANK);
+    }
+
+    @Test
+    void 당첨로또는_로또의_당첨등수를_알_수_있다_2등() {
+        // given
+        List<Integer> numbers = List.of(1, 2, 3, 4, 5, 11);
+        Lotto lotto = Lotto.ofManual(List.of(1, 2, 3, 4, 5, 7));
+        WinningLotto winningLotto = new WinningLotto(Lotto.ofManual(numbers), new LottoNumber(7));
+
+        // when
+        LottoRank place = winningLotto.getRank(lotto);
+
+        // then
+        assertThat(place).isEqualTo(LottoRank.SECOND_RANK);
     }
 }

--- a/src/test/java/dto/WinningLottoTest.java
+++ b/src/test/java/dto/WinningLottoTest.java
@@ -30,7 +30,7 @@ public class WinningLottoTest {
         WinningLotto winningLotto = new WinningLotto(Lotto.ofManual(numbers), new LottoNumber(7));
 
         // when
-        LottoRank place = winningLotto.getRank(lotto);
+        LottoRank place = winningLotto.getLottoRank(lotto);
 
         // then
         assertThat(place).isEqualTo(LottoRank.FIRST_RANK);
@@ -44,7 +44,7 @@ public class WinningLottoTest {
         WinningLotto winningLotto = new WinningLotto(Lotto.ofManual(numbers), new LottoNumber(7));
 
         // when
-        LottoRank place = winningLotto.getRank(lotto);
+        LottoRank place = winningLotto.getLottoRank(lotto);
 
         // then
         assertThat(place).isEqualTo(LottoRank.SECOND_RANK);


### PR DESCRIPTION
안녕하세요 맷! 저번 로또 1단계에 이어서 로또 2단계를 구현했습니다. 

2단계는 기존에 자동으로 로또 번호를 생성해서 구매하는 것에서 
수동으로 구매하고자하는 로또의 개수와 로또 번호를 입력해서 구매할 수 있게 추가 구현하는 것이었는데,
어떻게 이전 단계 코드를 활용하면서 추가 요구사항을 반영할 수 있을지 고민했던 것 같습니다.

변경사항을 요약하자면 아래와 같습니다!

### 변경사항
- `InputView`
   - 단순 String 반환 -> `NumberParser` 사용해 원시값을 포장한 형태로 반환 (Integer, List<Integer> 등)
   - 어플리케이션 로직 (`main()`) 내 흐름이 잘 보이도록 파싱까지 내부에서 수행
- `LottoStore`
    - 로또 구매시에 사용자가 입력한 로또 리스트(수동 로또)를 넘겨받음 
    - 구매된 로또 반환시 `List` -> `PurchasedLotto` (dto) 형태로 반환
    - 기존 자동 로또 구매 함수를 이용해 수동 로또 구매 후 남은 금액으로 자동 로또 구매
    - 구매금액의 유효성 검증 함수 분리
- `OutputView`
   - `List<Lotto>` -> `PurchasedLotto` 받아서 수동 로또와 자동 로또 개수 구분해서 출력
   
항상 리뷰 감사합니다! ✨