### PR TITLE
[kloong.96] 로또 미션 2단계 - 로또 번호 수동 입력

### DIFF
--- a/src/main/java/controller/LottoController.java
+++ b/src/main/java/controller/LottoController.java
@@ -18,9 +18,9 @@ public class LottoController {
         LottoTickets lottoTickets = lottoShop.buyLottoTickets(cost);
         lottoOutputView.printLottoTicketPurchaseCount(lottoTickets);
         lottoOutputView.printLottoTickets(lottoTickets);
-        LottoWinningNumber lottoWinningNumber = lottoInputView.readWinningNumber();
+        LottoWinningNumbers lottoWinningNumbers = lottoInputView.readLottoWinningNumbers();
 
-        LottoPrizeResult lottoPrizeResult = lottoTickets.matchTickets(lottoWinningNumber);
+        LottoPrizeResult lottoPrizeResult = lottoTickets.matchTickets(lottoWinningNumbers);
         LottoEarningRate lottoEarningRate = new LottoEarningRate(lottoPrizeResult, lottoTickets);
         lottoOutputView.printLottoPrizeResult(lottoPrizeResult);
         lottoOutputView.printEarningRate(lottoEarningRate);

--- a/src/main/java/controller/LottoController.java
+++ b/src/main/java/controller/LottoController.java
@@ -6,6 +6,8 @@ import domain.lotto.LottoShop;
 import view.LottoInputView;
 import view.LottoOutputView;
 
+import java.util.List;
+
 public class LottoController {
 
     private final LottoInputView lottoInputView = new LottoInputView();
@@ -15,9 +17,13 @@ public class LottoController {
 
     public void startLotto() {
         Cost cost = lottoInputView.readCost();
-        LottoTickets lottoTickets = lottoShop.buyLottoTickets(cost);
+        LottoTicketPurchaseAmount manualPurchaseAmount = lottoInputView.readLottoManualPurchaseAmount(cost);
+        List<LottoNumbers> manualLottoNumbers = lottoInputView.readManualLottoNumbers(manualPurchaseAmount);
+
+        LottoTickets lottoTickets = lottoShop.buyLottoTickets(manualLottoNumbers, cost);
         lottoOutputView.printLottoTicketPurchaseCount(lottoTickets);
         lottoOutputView.printLottoTickets(lottoTickets);
+
         LottoWinningNumbers lottoWinningNumbers = lottoInputView.readLottoWinningNumbers();
 
         LottoPrizeResult lottoPrizeResult = lottoTickets.matchTickets(lottoWinningNumbers);

--- a/src/main/java/domain/judgment/LottoPrizeJudgment.java
+++ b/src/main/java/domain/judgment/LottoPrizeJudgment.java
@@ -1,9 +1,9 @@
 package domain.judgment;
 
 import domain.lotto.LottoNumbers;
-import domain.lotto.LottoWinningNumber;
+import domain.lotto.LottoWinningNumbers;
 
 public interface LottoPrizeJudgment {
 
-    boolean judge(LottoNumbers lottoNumbers, LottoWinningNumber lottoWinningNumber);
+    boolean judge(LottoNumbers lottoNumbers, LottoWinningNumbers lottoWinningNumbers);
 }

--- a/src/main/java/domain/judgment/impl/FifthLottoPrizeJudgment.java
+++ b/src/main/java/domain/judgment/impl/FifthLottoPrizeJudgment.java
@@ -2,13 +2,13 @@ package domain.judgment.impl;
 
 import domain.judgment.LottoPrizeJudgment;
 import domain.lotto.LottoNumbers;
-import domain.lotto.LottoWinningNumber;
+import domain.lotto.LottoWinningNumbers;
 
 public class FifthLottoPrizeJudgment implements LottoPrizeJudgment {
 
     @Override
-    public boolean judge(LottoNumbers lottoNumbers, LottoWinningNumber lottoWinningNumber) {
-        LottoNumbers winningNumbers = lottoWinningNumber.getLottoNumbers();
+    public boolean judge(LottoNumbers lottoNumbers, LottoWinningNumbers lottoWinningNumbers) {
+        LottoNumbers winningNumbers = lottoWinningNumbers.getLottoNumbers();
         return lottoNumbers.countCommonLottoNumbers(winningNumbers) == 3;
     }
 }

--- a/src/main/java/domain/judgment/impl/FirstLottoPrizeJudgment.java
+++ b/src/main/java/domain/judgment/impl/FirstLottoPrizeJudgment.java
@@ -2,13 +2,13 @@ package domain.judgment.impl;
 
 import domain.judgment.LottoPrizeJudgment;
 import domain.lotto.LottoNumbers;
-import domain.lotto.LottoWinningNumber;
+import domain.lotto.LottoWinningNumbers;
 
 public class FirstLottoPrizeJudgment implements LottoPrizeJudgment {
 
     @Override
-    public boolean judge(LottoNumbers lottoNumbers, LottoWinningNumber lottoWinningNumber) {
-        LottoNumbers winningNumbers = lottoWinningNumber.getLottoNumbers();
+    public boolean judge(LottoNumbers lottoNumbers, LottoWinningNumbers lottoWinningNumbers) {
+        LottoNumbers winningNumbers = lottoWinningNumbers.getLottoNumbers();
         return lottoNumbers.countCommonLottoNumbers(winningNumbers) == 6;
     }
 

--- a/src/main/java/domain/judgment/impl/FourthLottoPrizeJudgment.java
+++ b/src/main/java/domain/judgment/impl/FourthLottoPrizeJudgment.java
@@ -2,13 +2,13 @@ package domain.judgment.impl;
 
 import domain.judgment.LottoPrizeJudgment;
 import domain.lotto.LottoNumbers;
-import domain.lotto.LottoWinningNumber;
+import domain.lotto.LottoWinningNumbers;
 
 public class FourthLottoPrizeJudgment implements LottoPrizeJudgment {
 
     @Override
-    public boolean judge(LottoNumbers lottoNumbers, LottoWinningNumber lottoWinningNumber) {
-        LottoNumbers winningNumbers = lottoWinningNumber.getLottoNumbers();
+    public boolean judge(LottoNumbers lottoNumbers, LottoWinningNumbers lottoWinningNumbers) {
+        LottoNumbers winningNumbers = lottoWinningNumbers.getLottoNumbers();
         return lottoNumbers.countCommonLottoNumbers(winningNumbers) == 4;
     }
 }

--- a/src/main/java/domain/judgment/impl/NoneLottoPrizeJudgment.java
+++ b/src/main/java/domain/judgment/impl/NoneLottoPrizeJudgment.java
@@ -2,13 +2,13 @@ package domain.judgment.impl;
 
 import domain.judgment.LottoPrizeJudgment;
 import domain.lotto.LottoNumbers;
-import domain.lotto.LottoWinningNumber;
+import domain.lotto.LottoWinningNumbers;
 
 public class NoneLottoPrizeJudgment implements LottoPrizeJudgment {
 
     @Override
-    public boolean judge(LottoNumbers lottoNumbers, LottoWinningNumber lottoWinningNumber) {
-        LottoNumbers winningNumbers = lottoWinningNumber.getLottoNumbers();
+    public boolean judge(LottoNumbers lottoNumbers, LottoWinningNumbers lottoWinningNumbers) {
+        LottoNumbers winningNumbers = lottoWinningNumbers.getLottoNumbers();
         return lottoNumbers.countCommonLottoNumbers(winningNumbers) <= 2;
     }
 }

--- a/src/main/java/domain/judgment/impl/SecondLottoPrizeJudgment.java
+++ b/src/main/java/domain/judgment/impl/SecondLottoPrizeJudgment.java
@@ -3,14 +3,14 @@ package domain.judgment.impl;
 import domain.judgment.LottoPrizeJudgment;
 import domain.lotto.LottoNumber;
 import domain.lotto.LottoNumbers;
-import domain.lotto.LottoWinningNumber;
+import domain.lotto.LottoWinningNumbers;
 
 public class SecondLottoPrizeJudgment implements LottoPrizeJudgment {
 
     @Override
-    public boolean judge(LottoNumbers lottoNumbers, LottoWinningNumber lottoWinningNumber) {
-        LottoNumbers winningNumbers = lottoWinningNumber.getLottoNumbers();
-        LottoNumber bonusNumber = lottoWinningNumber.getBonusNumber();
+    public boolean judge(LottoNumbers lottoNumbers, LottoWinningNumbers lottoWinningNumbers) {
+        LottoNumbers winningNumbers = lottoWinningNumbers.getLottoNumbers();
+        LottoNumber bonusNumber = lottoWinningNumbers.getBonusNumber();
         return lottoNumbers.countCommonLottoNumbers(winningNumbers) == 5 && lottoNumbers.contains(bonusNumber);
     }
 }

--- a/src/main/java/domain/judgment/impl/ThirdLottoPrizeJudgment.java
+++ b/src/main/java/domain/judgment/impl/ThirdLottoPrizeJudgment.java
@@ -2,13 +2,13 @@ package domain.judgment.impl;
 
 import domain.judgment.LottoPrizeJudgment;
 import domain.lotto.LottoNumbers;
-import domain.lotto.LottoWinningNumber;
+import domain.lotto.LottoWinningNumbers;
 
 public class ThirdLottoPrizeJudgment implements LottoPrizeJudgment {
 
     @Override
-    public boolean judge(LottoNumbers lottoNumbers, LottoWinningNumber lottoWinningNumber) {
-        LottoNumbers winningNumbers = lottoWinningNumber.getLottoNumbers();
+    public boolean judge(LottoNumbers lottoNumbers, LottoWinningNumbers lottoWinningNumbers) {
+        LottoNumbers winningNumbers = lottoWinningNumbers.getLottoNumbers();
         return lottoNumbers.countCommonLottoNumbers(winningNumbers) == 5;
     }
 }

--- a/src/main/java/domain/lotto/LottoEarningRate.java
+++ b/src/main/java/domain/lotto/LottoEarningRate.java
@@ -13,7 +13,7 @@ public class LottoEarningRate {
 
     public LottoEarningRate(LottoPrizeResult lottoPrizeResult, LottoTickets lottoTickets) {
         int prizeMoneySum = lottoPrizeResult.calculatePrizeMoneySum();
-        Cost cost = lottoTickets.calculatePurcaseCost();
+        Cost cost = lottoTickets.calculatePurchaseCost();
         double tempEarningRate = (double) prizeMoneySum / cost.getCost();
         validateEarningRate(tempEarningRate);
         this.earningRate = tempEarningRate;

--- a/src/main/java/domain/lotto/LottoPrize.java
+++ b/src/main/java/domain/lotto/LottoPrize.java
@@ -30,10 +30,10 @@ public enum LottoPrize implements Comparable<LottoPrize> {
         return prizeMoney;
     }
 
-    public static LottoPrize matchLottoNumbers(LottoNumbers lottoNumbers, LottoWinningNumber lottoWinningNumber) {
+    public static LottoPrize matchLottoNumbers(LottoNumbers lottoNumbers, LottoWinningNumbers lottoWinningNumbers) {
         List<LottoPrize> orderedLottoPrizes = getOrderedLottoPrizes();
         return orderedLottoPrizes.stream()
-                .filter(lottoPrize -> lottoPrize.prizeJudgment.judge(lottoNumbers, lottoWinningNumber))
+                .filter(lottoPrize -> lottoPrize.prizeJudgment.judge(lottoNumbers, lottoWinningNumbers))
                 .findFirst()
                 .orElseThrow(IllegalStateException::new);
     }

--- a/src/main/java/domain/lotto/LottoPrizeResult.java
+++ b/src/main/java/domain/lotto/LottoPrizeResult.java
@@ -12,10 +12,6 @@ public class LottoPrizeResult {
         this.prizeCounts = prizeCounts;
     }
 
-    public Map<LottoPrize, Integer> getPrizeCounts() {
-        return prizeCounts;
-    }
-
     public int calculatePrizeMoneySum() {
         return prizeCounts.entrySet().stream()
                 .mapToInt(prizeCount -> prizeCount.getKey().getPrizeMoney() * prizeCount.getValue())

--- a/src/main/java/domain/lotto/LottoShop.java
+++ b/src/main/java/domain/lotto/LottoShop.java
@@ -1,5 +1,6 @@
 package domain.lotto;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -15,11 +16,7 @@ public class LottoShop {
     }
 
     public LottoTickets buyLottoTickets(Cost cost) {
-        validateCost(cost);
-        List<LottoNumbers> tickets = IntStream.range(0, cost.countAvailablePurchases(LOTTO_PRICE))
-                .mapToObj(idx -> lottoNumbersGenerator.generate())
-                .collect(Collectors.toList());
-        return new LottoTickets(tickets);
+        return buyLottoTickets(Collections.emptyList(), cost);
     }
 
     public LottoTickets buyLottoTickets(List<LottoNumbers> manualLottoNumbers, Cost cost) {
@@ -35,15 +32,9 @@ public class LottoShop {
         return cost.countAvailablePurchases(LOTTO_PRICE) - manualLottoNumbers.size();
     }
 
-
     private void validate(List<LottoNumbers> manualLottoNumbers, Cost cost) {
-        if (cost.countAvailablePurchases(LOTTO_PRICE) < manualLottoNumbers.size()) {
-            throw new IllegalArgumentException("잔액이 부족합니다");
-        }
-    }
-
-    private void validateCost(Cost cost) {
-        if (cost.countAvailablePurchases(LOTTO_PRICE) <= 0) {
+        int availablePurchaseCount = cost.countAvailablePurchases(LOTTO_PRICE);
+        if (availablePurchaseCount <= 0 || availablePurchaseCount < manualLottoNumbers.size()) {
             throw new IllegalArgumentException("잔액이 부족합니다");
         }
     }

--- a/src/main/java/domain/lotto/LottoShop.java
+++ b/src/main/java/domain/lotto/LottoShop.java
@@ -22,6 +22,26 @@ public class LottoShop {
         return new LottoTickets(tickets);
     }
 
+    public LottoTickets buyLottoTickets(List<LottoNumbers> manualLottoNumbers, Cost cost) {
+        validate(manualLottoNumbers, cost);
+        List<LottoNumbers> autoLottoNumbers =
+                IntStream.range(0, countAvailableAutoLottoPurchase(manualLottoNumbers, cost))
+                .mapToObj(idx -> lottoNumbersGenerator.generate())
+                .collect(Collectors.toList());
+        return new LottoTickets(autoLottoNumbers, manualLottoNumbers);
+    }
+
+    private int countAvailableAutoLottoPurchase(List<LottoNumbers> manualLottoNumbers, Cost cost) {
+        return cost.countAvailablePurchases(LOTTO_PRICE) - manualLottoNumbers.size();
+    }
+
+
+    private void validate(List<LottoNumbers> manualLottoNumbers, Cost cost) {
+        if (cost.countAvailablePurchases(LOTTO_PRICE) < manualLottoNumbers.size()) {
+            throw new IllegalArgumentException("잔액이 부족합니다");
+        }
+    }
+
     private void validateCost(Cost cost) {
         if (cost.countAvailablePurchases(LOTTO_PRICE) <= 0) {
             throw new IllegalArgumentException("잔액이 부족합니다");

--- a/src/main/java/domain/lotto/LottoShop.java
+++ b/src/main/java/domain/lotto/LottoShop.java
@@ -1,10 +1,5 @@
 package domain.lotto;
 
-import domain.lotto.Cost;
-import domain.lotto.LottoNumbers;
-import domain.lotto.LottoNumbersGenerator;
-import domain.lotto.LottoTickets;
-
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;

--- a/src/main/java/domain/lotto/LottoTicketPurchaseAmount.java
+++ b/src/main/java/domain/lotto/LottoTicketPurchaseAmount.java
@@ -1,0 +1,9 @@
+package domain.lotto;
+
+public class LottoTicketPurchaseAmount {
+    private final int purchaseAmount;
+
+    public LottoTicketPurchaseAmount(int purchaseAmount, Cost cost) {
+        this.purchaseAmount = purchaseAmount;
+    }
+}

--- a/src/main/java/domain/lotto/LottoTicketPurchaseAmount.java
+++ b/src/main/java/domain/lotto/LottoTicketPurchaseAmount.java
@@ -9,6 +9,10 @@ public class LottoTicketPurchaseAmount {
         this.purchaseAmount = purchaseAmount;
     }
 
+    public int getPurchaseAmount() {
+        return purchaseAmount;
+    }
+
     private void validate(int purchaseAmount, Cost cost) {
         if (purchaseAmount < MINIMUM_PURCHASE_AMOUNT) {
             throw new IllegalArgumentException("로또 구매 개수는 0 이상이어야 합니다.");

--- a/src/main/java/domain/lotto/LottoTicketPurchaseAmount.java
+++ b/src/main/java/domain/lotto/LottoTicketPurchaseAmount.java
@@ -5,13 +5,16 @@ public class LottoTicketPurchaseAmount {
     private final int purchaseAmount;
 
     public LottoTicketPurchaseAmount(int purchaseAmount, Cost cost) {
-        validate(purchaseAmount);
+        validate(purchaseAmount, cost);
         this.purchaseAmount = purchaseAmount;
     }
 
-    private void validate(int purchaseAmount) {
+    private void validate(int purchaseAmount, Cost cost) {
         if (purchaseAmount < MINIMUM_PURCHASE_AMOUNT) {
             throw new IllegalArgumentException("로또 구매 개수는 0 이상이어야 합니다.");
+        }
+        if (cost.countAvailablePurchases(LottoShop.LOTTO_PRICE) < purchaseAmount) {
+            throw new IllegalArgumentException("잔액이 부족합니다.");
         }
     }
 }

--- a/src/main/java/domain/lotto/LottoTicketPurchaseAmount.java
+++ b/src/main/java/domain/lotto/LottoTicketPurchaseAmount.java
@@ -13,6 +13,10 @@ public class LottoTicketPurchaseAmount {
         return purchaseAmount;
     }
 
+    public boolean isZero() {
+        return purchaseAmount == 0;
+    }
+
     private void validate(int purchaseAmount, Cost cost) {
         if (purchaseAmount < MINIMUM_PURCHASE_AMOUNT) {
             throw new IllegalArgumentException("로또 구매 개수는 0 이상이어야 합니다.");

--- a/src/main/java/domain/lotto/LottoTicketPurchaseAmount.java
+++ b/src/main/java/domain/lotto/LottoTicketPurchaseAmount.java
@@ -1,9 +1,17 @@
 package domain.lotto;
 
 public class LottoTicketPurchaseAmount {
+    public static final int MINIMUM_PURCHASE_AMOUNT = 0;
     private final int purchaseAmount;
 
     public LottoTicketPurchaseAmount(int purchaseAmount, Cost cost) {
+        validate(purchaseAmount);
         this.purchaseAmount = purchaseAmount;
+    }
+
+    private void validate(int purchaseAmount) {
+        if (purchaseAmount < MINIMUM_PURCHASE_AMOUNT) {
+            throw new IllegalArgumentException("로또 구매 개수는 0 이상이어야 합니다.");
+        }
     }
 }

--- a/src/main/java/domain/lotto/LottoTickets.java
+++ b/src/main/java/domain/lotto/LottoTickets.java
@@ -4,26 +4,27 @@ import java.util.*;
 
 public class LottoTickets {
     private final List<LottoNumbers> autoTickets;
-    private List<LottoNumbers> manualTickets;
+    private final List<LottoNumbers> manualTickets;
 
     public LottoTickets(List<LottoNumbers> autoTickets) {
-        validateTickets(autoTickets);
-        this.autoTickets = autoTickets;
+        this(autoTickets, Collections.emptyList());
     }
 
     public LottoTickets(List<LottoNumbers> autoTickets, List<LottoNumbers> manualTickets) {
-        validateTickets(autoTickets);
-        validateTickets(manualTickets);
+        validateTickets(autoTickets, manualTickets);
         this.autoTickets = new ArrayList<>(autoTickets);
         this.manualTickets = new ArrayList<>(manualTickets);
     }
 
-    public List<LottoNumbers> getTickets() {
-        return new ArrayList<>(autoTickets);
+    public List<LottoNumbers> getAllTickets() {
+        List<LottoNumbers> allTickets = new ArrayList<>(autoTickets.size() + manualTickets.size());
+        allTickets.addAll(autoTickets);
+        allTickets.addAll(manualTickets);
+        return allTickets;
     }
 
     public Cost calculatePurcaseCost() {
-        return new Cost(autoTickets.size() * LottoShop.LOTTO_PRICE);
+        return new Cost(countAllTickets() * LottoShop.LOTTO_PRICE);
     }
 
     public LottoPrizeResult matchTickets(LottoWinningNumber lottoWinningNumber) {
@@ -31,19 +32,27 @@ public class LottoTickets {
         Arrays.stream(LottoPrize.values())
                 .forEach(prize -> prizeCounts.put(prize, 0));
 
-        autoTickets.stream()
+        getAllTickets().stream()
                 .map(lottoNumbers -> LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumber))
                 .forEach(lottoPrize -> prizeCounts.computeIfPresent(lottoPrize, (prize, count) -> count + 1));
 
         return new LottoPrizeResult(prizeCounts);
     }
 
-    public int getTicketCount() {
+    public int countAllTickets() {
+        return countAutoTickets() + countManualTickets();
+    }
+
+    public int countAutoTickets() {
         return autoTickets.size();
     }
 
-    private void validateTickets(List<LottoNumbers> tickets) {
-        if (tickets == null || tickets.isEmpty()) {
+    public int countManualTickets() {
+        return manualTickets.size();
+    }
+
+    private void validateTickets(List<LottoNumbers> autoTickets, List<LottoNumbers> manualTickets) {
+        if (autoTickets.isEmpty() && manualTickets.isEmpty()) {
             throw new IllegalArgumentException("로또 복권은 한 장 이상이어야 합니다.");
         }
     }

--- a/src/main/java/domain/lotto/LottoTickets.java
+++ b/src/main/java/domain/lotto/LottoTickets.java
@@ -3,19 +3,27 @@ package domain.lotto;
 import java.util.*;
 
 public class LottoTickets {
-    private final List<LottoNumbers> tickets;
+    private final List<LottoNumbers> autoTickets;
+    private List<LottoNumbers> manualTickets;
 
-    public LottoTickets(List<LottoNumbers> tickets) {
-        validateTickets(tickets);
-        this.tickets = new ArrayList<>(tickets);
+    public LottoTickets(List<LottoNumbers> autoTickets) {
+        validateTickets(autoTickets);
+        this.autoTickets = autoTickets;
+    }
+
+    public LottoTickets(List<LottoNumbers> autoTickets, List<LottoNumbers> manualTickets) {
+        validateTickets(autoTickets);
+        validateTickets(manualTickets);
+        this.autoTickets = new ArrayList<>(autoTickets);
+        this.manualTickets = new ArrayList<>(manualTickets);
     }
 
     public List<LottoNumbers> getTickets() {
-        return new ArrayList<>(tickets);
+        return new ArrayList<>(autoTickets);
     }
 
     public Cost calculatePurcaseCost() {
-        return new Cost(tickets.size() * LottoShop.LOTTO_PRICE);
+        return new Cost(autoTickets.size() * LottoShop.LOTTO_PRICE);
     }
 
     public LottoPrizeResult matchTickets(LottoWinningNumber lottoWinningNumber) {
@@ -23,7 +31,7 @@ public class LottoTickets {
         Arrays.stream(LottoPrize.values())
                 .forEach(prize -> prizeCounts.put(prize, 0));
 
-        tickets.stream()
+        autoTickets.stream()
                 .map(lottoNumbers -> LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumber))
                 .forEach(lottoPrize -> prizeCounts.computeIfPresent(lottoPrize, (prize, count) -> count + 1));
 
@@ -31,7 +39,7 @@ public class LottoTickets {
     }
 
     public int getTicketCount() {
-        return tickets.size();
+        return autoTickets.size();
     }
 
     private void validateTickets(List<LottoNumbers> tickets) {

--- a/src/main/java/domain/lotto/LottoTickets.java
+++ b/src/main/java/domain/lotto/LottoTickets.java
@@ -27,13 +27,13 @@ public class LottoTickets {
         return new Cost(countAllTickets() * LottoShop.LOTTO_PRICE);
     }
 
-    public LottoPrizeResult matchTickets(LottoWinningNumber lottoWinningNumber) {
+    public LottoPrizeResult matchTickets(LottoWinningNumbers lottoWinningNumbers) {
         Map<LottoPrize, Integer> prizeCounts = new EnumMap<>(LottoPrize.class);
         Arrays.stream(LottoPrize.values())
                 .forEach(prize -> prizeCounts.put(prize, 0));
 
         getAllTickets().stream()
-                .map(lottoNumbers -> LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumber))
+                .map(lottoNumbers -> LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumbers))
                 .forEach(lottoPrize -> prizeCounts.computeIfPresent(lottoPrize, (prize, count) -> count + 1));
 
         return new LottoPrizeResult(prizeCounts);

--- a/src/main/java/domain/lotto/LottoTickets.java
+++ b/src/main/java/domain/lotto/LottoTickets.java
@@ -23,7 +23,7 @@ public class LottoTickets {
         return allTickets;
     }
 
-    public Cost calculatePurcaseCost() {
+    public Cost calculatePurchaseCost() {
         return new Cost(countAllTickets() * LottoShop.LOTTO_PRICE);
     }
 

--- a/src/main/java/domain/lotto/LottoWinningNumbers.java
+++ b/src/main/java/domain/lotto/LottoWinningNumbers.java
@@ -2,12 +2,12 @@ package domain.lotto;
 
 import java.util.Objects;
 
-public class LottoWinningNumber {
+public class LottoWinningNumbers {
 
     private final LottoNumbers lottoNumbers;
     private final LottoNumber bonusNumber;
 
-    public LottoWinningNumber(LottoNumbers lottoNumbers, LottoNumber bonusNumber) {
+    public LottoWinningNumbers(LottoNumbers lottoNumbers, LottoNumber bonusNumber) {
         validateDuplicates(lottoNumbers, bonusNumber);
         this.lottoNumbers = lottoNumbers;
         this.bonusNumber = bonusNumber;
@@ -31,7 +31,7 @@ public class LottoWinningNumber {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        LottoWinningNumber that = (LottoWinningNumber) o;
+        LottoWinningNumbers that = (LottoWinningNumbers) o;
         return Objects.equals(lottoNumbers, that.lottoNumbers) && Objects.equals(bonusNumber, that.bonusNumber);
     }
 

--- a/src/main/java/view/LottoInputView.java
+++ b/src/main/java/view/LottoInputView.java
@@ -24,6 +24,9 @@ public class LottoInputView {
     }
 
     public List<LottoNumbers> readManualLottoNumbers(LottoTicketPurchaseAmount lottoTicketPurchaseAmount) {
+        if (lottoTicketPurchaseAmount.isZero()) {
+            return Collections.emptyList();
+        }
         System.out.println(System.lineSeparator() + "수동으로 구매할 로또 번호를 입력해 주세요.");
         return IntStream.range(0, lottoTicketPurchaseAmount.getPurchaseAmount())
                 .mapToObj(idx -> readLottoNumbers())

--- a/src/main/java/view/LottoInputView.java
+++ b/src/main/java/view/LottoInputView.java
@@ -1,12 +1,8 @@
 package view;
 
-import domain.lotto.Cost;
-import domain.lotto.LottoNumber;
-import domain.lotto.LottoNumbers;
-import domain.lotto.LottoWinningNumber;
+import domain.lotto.*;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -20,6 +16,12 @@ public class LottoInputView {
         int inputCost = Integer.parseInt(sc.nextLine());
 
         return new Cost(inputCost);
+    }
+
+    public LottoTicketPurchaseAmount readLottoManualPurchaseAmount(Cost purchaseCost) {
+        System.out.println("수동으로 구매할 로또 수를 입력해주세요.");
+        int purchaseAmount = Integer.parseInt(sc.nextLine());
+        return new LottoTicketPurchaseAmount(purchaseAmount, purchaseCost);
     }
 
     public LottoWinningNumber readWinningNumber() {

--- a/src/main/java/view/LottoInputView.java
+++ b/src/main/java/view/LottoInputView.java
@@ -2,10 +2,9 @@ package view;
 
 import domain.lotto.*;
 
-import java.util.Arrays;
-import java.util.Scanner;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class LottoInputView {
 
@@ -24,28 +23,34 @@ public class LottoInputView {
         return new LottoTicketPurchaseAmount(purchaseAmount, purchaseCost);
     }
 
+    public List<LottoNumbers> readManualLottoNumbers(LottoTicketPurchaseAmount lottoTicketPurchaseAmount) {
+        System.out.println(System.lineSeparator() + "수동으로 구매할 로또 번호를 입력해 주세요.");
+        return IntStream.range(0, lottoTicketPurchaseAmount.getPurchaseAmount())
+                .mapToObj(idx -> readLottoNumbers())
+                .collect(Collectors.toList());
+    }
+
     public LottoWinningNumbers readLottoWinningNumbers() {
-        LottoNumbers winningNumbers = readWinningNumbers();
+        System.out.println(System.lineSeparator() + "지난 주 당첨 번호를 입력해 주세요.");
+        LottoNumbers winningNumbers = readLottoNumbers();
+        System.out.println("보너스 볼을 입력해 주세요.");
         LottoNumber bonusNumber = readBonusNumber();
         return new LottoWinningNumbers(winningNumbers, bonusNumber);
     }
 
-    private LottoNumbers readWinningNumbers() {
-        System.out.println(System.lineSeparator() + "지난 주 당첨 번호를 입력해 주세요.");
+    private LottoNumbers readLottoNumbers() {
         String input = sc.nextLine();
         String[] inputStrings = input.split(",");
-        Set<LottoNumber> winningNumbers = Arrays.stream(inputStrings)
+        Set<LottoNumber> lottoNumbers = Arrays.stream(inputStrings)
                 .map(String::trim)
                 .mapToInt(Integer::parseInt)
                 .mapToObj(LottoNumber::new)
                 .collect(Collectors.toSet());
-        return new LottoNumbers(winningNumbers);
+        return new LottoNumbers(lottoNumbers);
     }
 
     private LottoNumber readBonusNumber() {
-        System.out.println("보너스 볼을 입력해 주세요.");
         int bonusBallNumber = Integer.parseInt(sc.nextLine());
-
         return new LottoNumber(bonusBallNumber);
     }
 }

--- a/src/main/java/view/LottoInputView.java
+++ b/src/main/java/view/LottoInputView.java
@@ -24,22 +24,22 @@ public class LottoInputView {
         return new LottoTicketPurchaseAmount(purchaseAmount, purchaseCost);
     }
 
-    public LottoWinningNumber readWinningNumber() {
-        LottoNumbers lottoNumbers = readLottoNumbers();
+    public LottoWinningNumbers readLottoWinningNumbers() {
+        LottoNumbers winningNumbers = readWinningNumbers();
         LottoNumber bonusNumber = readBonusNumber();
-        return new LottoWinningNumber(lottoNumbers, bonusNumber);
+        return new LottoWinningNumbers(winningNumbers, bonusNumber);
     }
 
-    private LottoNumbers readLottoNumbers() {
+    private LottoNumbers readWinningNumbers() {
         System.out.println(System.lineSeparator() + "지난 주 당첨 번호를 입력해 주세요.");
         String input = sc.nextLine();
         String[] inputStrings = input.split(",");
-        Set<LottoNumber> lottoNumbers = Arrays.stream(inputStrings)
+        Set<LottoNumber> winningNumbers = Arrays.stream(inputStrings)
                 .map(String::trim)
                 .mapToInt(Integer::parseInt)
                 .mapToObj(LottoNumber::new)
                 .collect(Collectors.toSet());
-        return new LottoNumbers(lottoNumbers);
+        return new LottoNumbers(winningNumbers);
     }
 
     private LottoNumber readBonusNumber() {

--- a/src/main/java/view/LottoInputView.java
+++ b/src/main/java/view/LottoInputView.java
@@ -18,7 +18,7 @@ public class LottoInputView {
     }
 
     public LottoTicketPurchaseAmount readLottoManualPurchaseAmount(Cost purchaseCost) {
-        System.out.println("수동으로 구매할 로또 수를 입력해주세요.");
+        System.out.println(System.lineSeparator() + "수동으로 구매할 로또 수를 입력해주세요.");
         int purchaseAmount = Integer.parseInt(sc.nextLine());
         return new LottoTicketPurchaseAmount(purchaseAmount, purchaseCost);
     }

--- a/src/main/java/view/LottoOutputView.java
+++ b/src/main/java/view/LottoOutputView.java
@@ -8,11 +8,11 @@ import java.util.stream.Collectors;
 public class LottoOutputView {
 
     public void printLottoTicketPurchaseCount(LottoTickets lottoTickets) {
-        System.out.println(lottoTickets.getTicketCount() + "개를 구매했습니다.");
+        System.out.println(lottoTickets.countAllTickets() + "개를 구매했습니다.");
     }
 
     public void printLottoTickets(LottoTickets lottoTickets) {
-        lottoTickets.getTickets().stream()
+        lottoTickets.getAllTickets().stream()
                 .map(LottoNumbers::getNumbers)
                 .forEach(this::printLottoNumbers);
     }

--- a/src/main/java/view/LottoOutputView.java
+++ b/src/main/java/view/LottoOutputView.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 public class LottoOutputView {
 
     public void printLottoTicketPurchaseCount(LottoTickets lottoTickets) {
-        System.out.printf("수동으로 %d장, 자동으로 %d장을 구매했습니다.",
+        System.out.printf("%n수동으로 %d장, 자동으로 %d장을 구매했습니다.%n",
                 lottoTickets.countManualTickets(), lottoTickets.countAutoTickets());
     }
 

--- a/src/main/java/view/LottoOutputView.java
+++ b/src/main/java/view/LottoOutputView.java
@@ -8,7 +8,8 @@ import java.util.stream.Collectors;
 public class LottoOutputView {
 
     public void printLottoTicketPurchaseCount(LottoTickets lottoTickets) {
-        System.out.println(lottoTickets.countAllTickets() + "개를 구매했습니다.");
+        System.out.printf("수동으로 %d장, 자동으로 %d장을 구매했습니다.",
+                lottoTickets.countManualTickets(), lottoTickets.countManualTickets());
     }
 
     public void printLottoTickets(LottoTickets lottoTickets) {

--- a/src/main/java/view/LottoOutputView.java
+++ b/src/main/java/view/LottoOutputView.java
@@ -9,7 +9,7 @@ public class LottoOutputView {
 
     public void printLottoTicketPurchaseCount(LottoTickets lottoTickets) {
         System.out.printf("수동으로 %d장, 자동으로 %d장을 구매했습니다.",
-                lottoTickets.countManualTickets(), lottoTickets.countManualTickets());
+                lottoTickets.countManualTickets(), lottoTickets.countAutoTickets());
     }
 
     public void printLottoTickets(LottoTickets lottoTickets) {

--- a/src/test/java/domain/lotto/LottoPrizeTest.java
+++ b/src/test/java/domain/lotto/LottoPrizeTest.java
@@ -9,7 +9,7 @@ import java.util.Set;
 
 class LottoPrizeTest {
 
-    LottoWinningNumber lottoWinningNumber;
+    LottoWinningNumbers lottoWinningNumbers;
     LottoNumbers lottoNumbers;
 
     @BeforeEach
@@ -24,7 +24,7 @@ class LottoPrizeTest {
         ));
 
         LottoNumber bonusNumber = new LottoNumber(10);
-        lottoWinningNumber = new LottoWinningNumber(lottoNumbers, bonusNumber);
+        lottoWinningNumbers = new LottoWinningNumbers(lottoNumbers, bonusNumber);
     }
 
     @DisplayName("다 맞으면 1등이다.")
@@ -39,7 +39,7 @@ class LottoPrizeTest {
                 new LottoNumber(6)
         ));
 
-        LottoPrize prize = LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumber);
+        LottoPrize prize = LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumbers);
         Assertions.assertThat(prize)
                 .isEqualTo(LottoPrize.FIRST_PRIZE);
     }
@@ -56,7 +56,7 @@ class LottoPrizeTest {
                 new LottoNumber(10)
         ));
 
-        LottoPrize prize = LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumber);
+        LottoPrize prize = LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumbers);
         Assertions.assertThat(prize)
                 .isEqualTo(LottoPrize.SECOND_PRIZE);
     }
@@ -73,7 +73,7 @@ class LottoPrizeTest {
                 new LottoNumber(41)
         ));
 
-        LottoPrize prize = LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumber);
+        LottoPrize prize = LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumbers);
         Assertions.assertThat(prize)
                 .isEqualTo(LottoPrize.THIRD_PRIZE);
     }
@@ -90,7 +90,7 @@ class LottoPrizeTest {
                 new LottoNumber(42)
         ));
 
-        LottoPrize prize = LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumber);
+        LottoPrize prize = LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumbers);
         Assertions.assertThat(prize)
                 .isEqualTo(LottoPrize.FOURTH_PRIZE);
     }
@@ -107,7 +107,7 @@ class LottoPrizeTest {
                 new LottoNumber(43)
         ));
 
-        LottoPrize prize = LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumber);
+        LottoPrize prize = LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumbers);
         Assertions.assertThat(prize)
                 .isEqualTo(LottoPrize.FIFTH_PRIZE);
     }
@@ -124,7 +124,7 @@ class LottoPrizeTest {
                 new LottoNumber(43)
         ));
 
-        LottoPrize prize = LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumber);
+        LottoPrize prize = LottoPrize.matchLottoNumbers(lottoNumbers, lottoWinningNumbers);
         Assertions.assertThat(prize)
                 .isEqualTo(LottoPrize.NONE_PRIZE);
     }

--- a/src/test/java/domain/lotto/LottoShopTest.java
+++ b/src/test/java/domain/lotto/LottoShopTest.java
@@ -1,6 +1,5 @@
 package domain.lotto;
 
-import domain.lotto.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -18,7 +17,7 @@ public class LottoShopTest {
                 new LottoNumbersRandomGenerator(LottoNumber.MINIMUM_NUMBER, LottoNumber.MAXIMUM_NUMBER));
 
         LottoTickets lottoTickets = lottoShop.buyLottoTickets(cost);
-        assertThat(lottoTickets.getTicketCount())
+        assertThat(lottoTickets.countAllTickets())
                 .isEqualTo(money / LottoShop.LOTTO_PRICE);
     }
 

--- a/src/test/java/domain/lotto/LottoShopTest.java
+++ b/src/test/java/domain/lotto/LottoShopTest.java
@@ -4,6 +4,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import static org.assertj.core.api.Assertions.*;
 
 public class LottoShopTest {
@@ -32,4 +36,48 @@ public class LottoShopTest {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> lottoShop.buyLottoTickets(cost));
     }
+
+    @DisplayName("수동 로또를 구매하고, 남는 돈으로 자동 로또를 구매한다")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 10})
+    void buyLottoTickets_manual(int countOfManuals) {
+        LottoNumbersGenerator lottoNumbersGenerator =
+                new LottoNumbersRandomGenerator(LottoNumber.MINIMUM_NUMBER, LottoNumber.MAXIMUM_NUMBER);
+
+        List<LottoNumbers> manualLottoNumbers = IntStream.range(0, countOfManuals)
+                .mapToObj(idx -> lottoNumbersGenerator.generate())
+                .collect(Collectors.toList());
+
+        LottoShop lottoShop = new LottoShop(
+                new LottoNumbersRandomGenerator(LottoNumber.MINIMUM_NUMBER, LottoNumber.MAXIMUM_NUMBER));
+
+        int money = LottoShop.LOTTO_PRICE * 10;
+        Cost cost = new Cost(money);
+
+        LottoTickets lottoTickets = lottoShop.buyLottoTickets(manualLottoNumbers, cost);
+        assertThat(lottoTickets.countAllTickets()).isEqualTo(cost.countAvailablePurchases(LottoShop.LOTTO_PRICE));
+        assertThat(lottoTickets.countManualTickets()).isEqualTo(countOfManuals);
+        assertThat(lottoTickets.countAutoTickets()).isEqualTo(cost.countAvailablePurchases(LottoShop.LOTTO_PRICE) - countOfManuals);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, LottoShop.LOTTO_PRICE, LottoShop.LOTTO_PRICE * 9})
+    @DisplayName("수동 로또 구매 금액보다 cost가 모자라는 경우에는 예외가 발생한다.")
+    void buyLottoTickets_manual_throw(int money) {
+        Cost cost = new Cost(money);
+
+        LottoNumbersGenerator lottoNumbersGenerator =
+                new LottoNumbersRandomGenerator(LottoNumber.MINIMUM_NUMBER, LottoNumber.MAXIMUM_NUMBER);
+
+        List<LottoNumbers> manualLottoNumbers = IntStream.range(0, 10)
+                .mapToObj(idx -> lottoNumbersGenerator.generate())
+                .collect(Collectors.toList());
+
+        LottoShop lottoShop = new LottoShop(
+                new LottoNumbersRandomGenerator(LottoNumber.MINIMUM_NUMBER, LottoNumber.MAXIMUM_NUMBER));
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> lottoShop.buyLottoTickets(manualLottoNumbers, cost));
+    }
+
 }

--- a/src/test/java/domain/lotto/LottoTicketPurchaseAmountTest.java
+++ b/src/test/java/domain/lotto/LottoTicketPurchaseAmountTest.java
@@ -26,4 +26,14 @@ public class LottoTicketPurchaseAmountTest {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> new LottoTicketPurchaseAmount(purchaseAmount, cost));
     }
+
+    @DisplayName("Cost로 구매 개수만큼의 로또를 구매할 수 없으면 예외 발생")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 500, 1000, 5000, 7900, 9999})
+    void create_throw_cost(int money) {
+        int purchaseCount = 10;
+        Cost cost = new Cost(money);
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new LottoTicketPurchaseAmount(purchaseCount, cost));
+    }
 }

--- a/src/test/java/domain/lotto/LottoTicketPurchaseAmountTest.java
+++ b/src/test/java/domain/lotto/LottoTicketPurchaseAmountTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class LottoTicketPurchaseAmountTest {
@@ -14,6 +15,15 @@ public class LottoTicketPurchaseAmountTest {
     void create(int purchaseAmount) {
         Cost cost = new Cost(10_000);
         assertThatNoException()
+                .isThrownBy(() -> new LottoTicketPurchaseAmount(purchaseAmount, cost));
+    }
+
+    @DisplayName("로또 구매 개수가 음수이면 예외가 발생한다")
+    @ParameterizedTest
+    @ValueSource(ints = {-1, -10})
+    void create_throw_negative(int purchaseAmount) {
+        Cost cost = new Cost(10_000);
+        assertThatIllegalArgumentException()
                 .isThrownBy(() -> new LottoTicketPurchaseAmount(purchaseAmount, cost));
     }
 }

--- a/src/test/java/domain/lotto/LottoTicketPurchaseAmountTest.java
+++ b/src/test/java/domain/lotto/LottoTicketPurchaseAmountTest.java
@@ -1,0 +1,19 @@
+package domain.lotto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+public class LottoTicketPurchaseAmountTest {
+
+    @DisplayName("Cost와 로또 구매 개수를 넘겨 받아서 로또 구매 개수 객체를 생성한다.")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 10})
+    void create(int purchaseAmount) {
+        Cost cost = new Cost(10_000);
+        assertThatNoException()
+                .isThrownBy(() -> new LottoTicketPurchaseAmount(purchaseAmount, cost));
+    }
+}

--- a/src/test/java/domain/lotto/LottoTicketsTest.java
+++ b/src/test/java/domain/lotto/LottoTicketsTest.java
@@ -15,10 +15,19 @@ import static org.assertj.core.api.Assertions.*;
 
 public class LottoTicketsTest {
     LottoNumbersGenerator lottoNumbersGenerator;
+    LottoNumbers lottoNumbers;
 
     @BeforeEach
     void setUp() {
         lottoNumbersGenerator = new LottoNumbersRandomGenerator(LottoNumber.MINIMUM_NUMBER, LottoNumber.MAXIMUM_NUMBER);
+        lottoNumbers = new LottoNumbers(Set.of(
+                new LottoNumber(1),
+                new LottoNumber(2),
+                new LottoNumber(3),
+                new LottoNumber(4),
+                new LottoNumber(5),
+                new LottoNumber(6)
+        ));
     }
 
     @DisplayName("LottoNumbers의 List를 넘겨받아서 LottoTickets를 생성한다.")
@@ -58,15 +67,6 @@ public class LottoTicketsTest {
     @DisplayName("당첨 번호와 비교해서 로또 당첨 결과를 반환한다. - 1등")
     @Test
     void matchTickets1() {
-        LottoNumbers lottoNumbers = new LottoNumbers(Set.of(
-                new LottoNumber(1),
-                new LottoNumber(2),
-                new LottoNumber(3),
-                new LottoNumber(4),
-                new LottoNumber(5),
-                new LottoNumber(6)
-        ));
-
         LottoTickets lottoTickets = new LottoTickets(List.of(lottoNumbers));
 
         LottoWinningNumber lottoWinningNumber = new LottoWinningNumber(lottoNumbers, new LottoNumber(45));
@@ -86,15 +86,6 @@ public class LottoTicketsTest {
     @DisplayName("당첨 번호와 비교해서 로또 당첨 결과를 반환한다. - 2등")
     @Test
     void countPrize2() {
-        LottoNumbers lottoNumbers = new LottoNumbers(Set.of(
-                new LottoNumber(1),
-                new LottoNumber(2),
-                new LottoNumber(3),
-                new LottoNumber(4),
-                new LottoNumber(5),
-                new LottoNumber(6)
-        ));
-
         LottoTickets lottoTickets = new LottoTickets(List.of(lottoNumbers));
 
         LottoNumbers winningNumbers = new LottoNumbers(Set.of(

--- a/src/test/java/domain/lotto/LottoTicketsTest.java
+++ b/src/test/java/domain/lotto/LottoTicketsTest.java
@@ -121,7 +121,7 @@ public class LottoTicketsTest {
 
         LottoTickets lottoTickets = new LottoTickets(tickets);
 
-        assertThat(lottoTickets.getTicketCount()).isEqualTo(ticketCount);
+        assertThat(lottoTickets.countAllTickets()).isEqualTo(ticketCount);
     }
 
     @DisplayName("수동 로또 번호와 자동 로또 번호로 LottoTickets를 생성한다")

--- a/src/test/java/domain/lotto/LottoTicketsTest.java
+++ b/src/test/java/domain/lotto/LottoTicketsTest.java
@@ -123,4 +123,15 @@ public class LottoTicketsTest {
 
         assertThat(lottoTickets.getTicketCount()).isEqualTo(ticketCount);
     }
+
+    @DisplayName("수동 로또 번호와 자동 로또 번호로 LottoTickets를 생성한다")
+    @Test
+    void create_manualAndAuto() {
+        LottoNumbers autoLottoNumbers = lottoNumbersGenerator.generate();
+        List<LottoNumbers> manualTickets = List.of(lottoNumbers);
+        List<LottoNumbers> autoTickets = List.of(autoLottoNumbers);
+
+        assertThatNoException()
+                .isThrownBy(() -> new LottoTickets(manualTickets, autoTickets));
+    }
 }

--- a/src/test/java/domain/lotto/LottoTicketsTest.java
+++ b/src/test/java/domain/lotto/LottoTicketsTest.java
@@ -69,7 +69,7 @@ public class LottoTicketsTest {
     void matchTickets1() {
         LottoTickets lottoTickets = new LottoTickets(List.of(lottoNumbers));
 
-        LottoWinningNumber lottoWinningNumber = new LottoWinningNumber(lottoNumbers, new LottoNumber(45));
+        LottoWinningNumbers lottoWinningNumbers = new LottoWinningNumbers(lottoNumbers, new LottoNumber(45));
 
         Map<LottoPrize, Integer> expectedMap = new EnumMap<>(LottoPrize.class);
         Arrays.stream(LottoPrize.values())
@@ -78,7 +78,7 @@ public class LottoTicketsTest {
 
         LottoPrizeResult expected = new LottoPrizeResult(expectedMap);
 
-        LottoPrizeResult result = lottoTickets.matchTickets(lottoWinningNumber);
+        LottoPrizeResult result = lottoTickets.matchTickets(lottoWinningNumbers);
 
         Assertions.assertThat(result).isEqualTo(expected);
     }
@@ -97,7 +97,7 @@ public class LottoTicketsTest {
                 new LottoNumber(45)
         ));
 
-        LottoWinningNumber lottoWinningNumber = new LottoWinningNumber(winningNumbers, new LottoNumber(6));
+        LottoWinningNumbers lottoWinningNumbers = new LottoWinningNumbers(winningNumbers, new LottoNumber(6));
 
         Map<LottoPrize, Integer> expectedMap = new EnumMap<>(LottoPrize.class);
         Arrays.stream(LottoPrize.values())
@@ -106,7 +106,7 @@ public class LottoTicketsTest {
 
         LottoPrizeResult expected = new LottoPrizeResult(expectedMap);
 
-        LottoPrizeResult result = lottoTickets.matchTickets(lottoWinningNumber);
+        LottoPrizeResult result = lottoTickets.matchTickets(lottoWinningNumbers);
 
         Assertions.assertThat(result).isEqualTo(expected);
     }

--- a/src/test/java/domain/lotto/LottoTicketsTest.java
+++ b/src/test/java/domain/lotto/LottoTicketsTest.java
@@ -58,7 +58,7 @@ public class LottoTicketsTest {
 
         LottoTickets lottoTickets = new LottoTickets(tickets);
 
-        Cost cost = lottoTickets.calculatePurcaseCost();
+        Cost cost = lottoTickets.calculatePurchaseCost();
 
         assertThat(cost).isEqualTo(new Cost(LottoShop.LOTTO_PRICE * ticketCount));
     }

--- a/src/test/java/domain/lotto/LottoWinningNumbersTest.java
+++ b/src/test/java/domain/lotto/LottoWinningNumbersTest.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
 
-public class LottoWinningNumberTest {
+public class LottoWinningNumbersTest {
 
     LottoNumbers lottoNumbers;
 
@@ -33,7 +33,7 @@ public class LottoWinningNumberTest {
         LottoNumber bonusNumber = new LottoNumber(10);
 
         assertThatNoException()
-                .isThrownBy(() -> new LottoWinningNumber(lottoNumbers, bonusNumber));
+                .isThrownBy(() -> new LottoWinningNumbers(lottoNumbers, bonusNumber));
     }
 
     @DisplayName("당첨 번호 중 보너스 번호와 중복된 번호가 있으면 예외가 발생한다")
@@ -43,6 +43,6 @@ public class LottoWinningNumberTest {
         LottoNumber bonusNumber = new LottoNumber(number);
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> new LottoWinningNumber(lottoNumbers, bonusNumber));
+                .isThrownBy(() -> new LottoWinningNumbers(lottoNumbers, bonusNumber));
     }
 }


### PR DESCRIPTION
안녕하세요 nesoy.
merge 한지 얼마 되지도 않았는데 바로 2단계 PR을 하네요 ㅎㅎ...

2단계에서는 사실 크게 바뀐게 없습니다. 로또 번호를 수동으로 입력받을 수 있게 해서 수동 구매와 자동 구매가 둘 다 가능하도록 바꿨습니다.
큰 변화가 있던 부분은 아래와 같습니다.

### LottoTickets
내부에 가지고 있던 `List<LottoNumbers> tickets`를 수동과 자동으로 구분했습니다. `List<LottoNumbers> autoTickets` , `List<LottoNumbers> manualTickets` 요렇게요.
그래서 수동으로 몇 장, 자동으로 몇 장 구매했는지 간단하게 알 수 있게 구현했습니다.

검증에서 살짝 변화가 있었는데, 수동 0장 / 자동 10장, 혹은 수동 10장 / 자동 0장 이렇게 둘중 하나는 0장 구매가 가능하게 되었습니다. 그래서 관련된 검증 코드 로직이 바뀌었습니다.

### LottoShop
로또를 구매를 담당하는 객체라서 많이 바뀐 듯 하지만, 실질적으로 관련 로직을 `LottoTickets`이 어느정도 구현하고 있기 때문에 수동 로또 번호를 생성자로 넘겨받는 거 말고는 크게 바뀐 건 없습니다.

### LottoTicketPurchaseAmount
구매할 로또 티켓 개수에 대한 객체입니다. "로또 티켓 구매" 수량이기 때문에 생성자에서 구매 수량과 `Cost` 를 함께 넘겨 받아서 cost를 가지고 해당 수량 만큼의 로또를 구매할 수 있는지 검증하는 로직이 구현되어 있습니다.

구매 수량을 입력 받은 cost 값으로 바로 검증을 해서 잔액이 부족하면 예외를 터트리려고 이렇게 구현을 했습니다.
만약 `LottoShop`에서 구매를 하는 타이밍에 잔액 체크를 하는 식으로 로직을 구현하면, 로또 번호를 수동으로 다 입력 받은 이후에 예외가 터지기 때문에 이런 방식을 선택했습니다.

### LottoInputView
수동 로또 구매 수량과 수동 로또 번호 입력 로직을 추가했습니다. 검증은 이미 다른 도메인 객체에 다 구현 되어있어서 메소드만 좀 추가하는 느낌으로 변경했습니다.

행복한 놀금 + 주말 되세요! 감사합니다~